### PR TITLE
Fix launchFlow CE propagation + consumer-correctness docs (#15, #17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`DefaultBillingRepository.launchFlow` now propagates
+  `CancellationException` correctly.** The prior broad `catch (e: Exception)`
+  block would wrap a `CancellationException` into a `BillingException`,
+  silently breaking structured cancellation when the surrounding scope was
+  torn down. Added a dedicated `catch (ce: CancellationException) { throw ce }`
+  arm before the general wrapping logic so `launchFlow` upholds the same CE
+  contract as every other suspend member. Surfaced by Copilot review of PR
+  #19 against the (#15) doc claim that the contract was already universal.
+
 ### Changed
 
-- **`BillingActions` class-level KDoc** gains a "Wrapping suspend members in
-  `runCatching`" note: every suspend member rethrows
+- **`BillingActions` class-level KDoc** gains a "Wrapping suspend members for
+  resilience" note: every suspend member rethrows
   `kotlinx.coroutines.CancellationException` internally for structured-cancellation
-  correctness, but `runCatching` catches all `Throwable` (including
+  correctness, but `runCatching { ... }` catches all `Throwable` (including
   `CancellationException`) and silently re-introduces the swallow-CE footgun
-  at the consumer layer. The note tells consumers to rethrow CE explicitly
-  inside their `runCatching` wrapper. (#15)
+  at the consumer layer. The note recommends explicit `try/catch` with a
+  `CancellationException` rethrow rather than `runCatching`. (#15)
 - **`BillingPurchaseUpdatesOwner.observePurchaseUpdates` KDoc** gains an
-  equivalent CE-rethrow note — long-lived collectors are the most common
-  `runCatching` site, so the warning is repeated there for visibility. (#15)
+  equivalent resilience note — long-lived collectors are the most common
+  cancellation-swallowing site, so the warning is repeated there for
+  visibility. (#15)
 - **`BillingActions.launchFlow` KDoc** expanded with the dual throw-vs-event
   contract: synchronous PBL errors (invalid activity, `NullPointerException`
   from `client.launchBillingFlow`, other `Exception`s, and any non-`OK`
@@ -28,7 +40,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `observePurchaseUpdates` as `FlowOutcome` variants. Calls out that
   `ITEM_ALREADY_OWNED` is dual-path and must be handled in both the
   `try/catch` around `launchFlow` *and* the `FlowOutcome.ItemAlreadyOwned`
-  branch in the collector. (#17)
+  branch in the collector. Also clarifies that the returned coroutine
+  completes once `BillingClient.launchBillingFlow` has returned (i.e., the
+  request was submitted to Play) — PBL exposes no "UI rendered" signal, so
+  completion is not a visibility guarantee. (#17)
 
 ## [0.1.1] - 2026-05-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,15 +15,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   silently breaking structured cancellation when the surrounding scope was
   torn down. Added a dedicated `catch (ce: CancellationException) { throw ce }`
   arm before the general wrapping logic so `launchFlow` upholds the same CE
-  contract as every other suspend member. Surfaced by Copilot review of PR
-  #19 against the (#15) doc claim that the contract was already universal.
+  contract as every other suspend member. (#15)
 
 ### Changed
 
 - **`BillingActions` class-level KDoc** gains a "Wrapping suspend members for
-  resilience" note: every suspend member rethrows
-  `kotlinx.coroutines.CancellationException` internally for structured-cancellation
-  correctness, but `runCatching { ... }` catches all `Throwable` (including
+  resilience" note explaining that suspend members propagate structured
+  cancellation (parent-scope `CancellationException` is rethrown; an internal
+  `withTimeout`'s `TimeoutCancellationException` is intentionally converted
+  to a `BillingException` because it represents a billing-layer failure),
+  and that `runCatching { ... }` catches all `Throwable` (including
   `CancellationException`) and silently re-introduces the swallow-CE footgun
   at the consumer layer. The note recommends explicit `try/catch` with a
   `CancellationException` rethrow rather than `runCatching`. (#15)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`BillingActions` class-level KDoc** gains a "Wrapping suspend members in
+  `runCatching`" note: every suspend member rethrows
+  `kotlinx.coroutines.CancellationException` internally for structured-cancellation
+  correctness, but `runCatching` catches all `Throwable` (including
+  `CancellationException`) and silently re-introduces the swallow-CE footgun
+  at the consumer layer. The note tells consumers to rethrow CE explicitly
+  inside their `runCatching` wrapper. (#15)
+- **`BillingPurchaseUpdatesOwner.observePurchaseUpdates` KDoc** gains an
+  equivalent CE-rethrow note — long-lived collectors are the most common
+  `runCatching` site, so the warning is repeated there for visibility. (#15)
+- **`BillingActions.launchFlow` KDoc** expanded with the dual throw-vs-event
+  contract: synchronous PBL errors (invalid activity, `NullPointerException`
+  from `client.launchBillingFlow`, other `Exception`s, and any non-`OK`
+  `BillingResponseCode` returned synchronously — including
+  `ITEM_ALREADY_OWNED` when PBL knows without showing UI) surface as thrown
+  `BillingException` subtypes, while UI-mediated outcomes arrive on
+  `observePurchaseUpdates` as `FlowOutcome` variants. Calls out that
+  `ITEM_ALREADY_OWNED` is dual-path and must be handled in both the
+  `try/catch` around `launchFlow` *and* the `FlowOutcome.ItemAlreadyOwned`
+  branch in the collector. (#17)
+
 ## [0.1.1] - 2026-05-03
 
 ### Breaking

--- a/billing/src/main/kotlin/com/kanetik/billing/BillingActions.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/BillingActions.kt
@@ -38,10 +38,15 @@ import com.kanetik.billing.exception.BillingException
  *     billing.queryPurchases(params)
  * } catch (e: kotlinx.coroutines.CancellationException) {
  *     throw e
- * } catch (e: Throwable) {
+ * } catch (e: Exception) {
  *     // log / handle non-cancellation failures
  * }
  * ```
+ *
+ * `Exception` (not `Throwable`) so JVM `Error`s — `OutOfMemoryError`,
+ * `LinkageError`, etc. — propagate; the library's own catch chains in
+ * [handlePurchase] follow the same rule and rethrow `VirtualMachineError`,
+ * `LinkageError`, and `ThreadDeath` explicitly before any broad catch.
  *
  * This is general kotlinx-coroutines hygiene (not billing-specific) but worth
  * calling out because long-lived collectors of

--- a/billing/src/main/kotlin/com/kanetik/billing/BillingActions.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/BillingActions.kt
@@ -283,10 +283,14 @@ public interface BillingActions {
     /**
      * Launches the Play Billing purchase flow.
      *
-     * Must be called on the main thread. The returned coroutine completes once Play
-     * has shown the purchase UI; the actual purchase outcome arrives separately via
-     * [BillingPurchaseUpdatesOwner.observePurchaseUpdates] (and may take seconds to
-     * minutes — pending purchases can sit unresolved indefinitely).
+     * Must be called on the main thread. The returned coroutine completes once
+     * `BillingClient.launchBillingFlow` has returned — i.e., once the launch request
+     * has been submitted to Play. PBL does not surface a "UI has rendered" signal,
+     * so completion of this call is **not** a guarantee that the purchase sheet is
+     * (or ever will be) on screen; it is only a guarantee that no synchronous error
+     * was raised during submission. The actual purchase outcome arrives separately
+     * via [BillingPurchaseUpdatesOwner.observePurchaseUpdates] (and may take seconds
+     * to minutes — pending purchases can sit unresolved indefinitely).
      *
      * For one-time products, prefer [com.kanetik.billing.ext.toOneTimeFlowParams] to
      * build [params] correctly under PBL 8's offer-token rules. For higher-level

--- a/billing/src/main/kotlin/com/kanetik/billing/BillingActions.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/BillingActions.kt
@@ -23,22 +23,29 @@ import com.kanetik.billing.exception.BillingException
  * failures, and surfaces hard failures as a typed [BillingException] subtype so
  * consumers can branch by [com.kanetik.billing.RetryType] without parsing strings.
  *
- * ## Wrapping suspend members in `runCatching`
+ * ## Wrapping suspend members for resilience
  *
  * Suspend members rethrow [kotlinx.coroutines.CancellationException] internally so
- * structured cancellation propagates correctly. If you wrap a call in
- * `runCatching { ... }` for resilience, rethrow `CancellationException` from your
- * wrapper too — the standard `runCatching` catches every `Throwable`, including
- * `CancellationException`, which silently swallows scope cancellation:
+ * structured cancellation propagates correctly. If you wrap a call to absorb
+ * non-billing failures (e.g. inside a long-lived collector that should not die
+ * on a transient billing error), use an explicit `try/catch` that **rethrows**
+ * `CancellationException` rather than `runCatching { ... }` — the standard
+ * `runCatching` catches every `Throwable`, including `CancellationException`,
+ * and silently swallows scope cancellation:
  *
  * ```
- * val result = runCatching { billing.queryPurchases(params) }
- *     .onFailure { if (it is kotlinx.coroutines.CancellationException) throw it }
+ * try {
+ *     billing.queryPurchases(params)
+ * } catch (e: kotlinx.coroutines.CancellationException) {
+ *     throw e
+ * } catch (e: Throwable) {
+ *     // log / handle non-cancellation failures
+ * }
  * ```
  *
  * This is general kotlinx-coroutines hygiene (not billing-specific) but worth
  * calling out because long-lived collectors of
- * [BillingPurchaseUpdatesOwner.observePurchaseUpdates] and `runCatching`-wrapped
+ * [BillingPurchaseUpdatesOwner.observePurchaseUpdates] and resilience-wrapped
  * `BillingActions` calls are the two most common sites where this footgun bites.
  */
 public interface BillingActions {
@@ -370,7 +377,7 @@ public interface BillingActions {
      * @throws BillingException any synchronous failure as described above. As with
      *   every other suspend member, [kotlinx.coroutines.CancellationException] is
      *   rethrown internally and must propagate — see the class-level KDoc for the
-     *   `runCatching` wrapping rule.
+     *   resilience-wrapping rule.
      */
     @MainThread
     public suspend fun launchFlow(activity: Activity, params: BillingFlowParams)

--- a/billing/src/main/kotlin/com/kanetik/billing/BillingActions.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/BillingActions.kt
@@ -22,6 +22,24 @@ import com.kanetik.billing.exception.BillingException
  * connection (see [BillingConnector]), runs with internal retry / backoff for transient
  * failures, and surfaces hard failures as a typed [BillingException] subtype so
  * consumers can branch by [com.kanetik.billing.RetryType] without parsing strings.
+ *
+ * ## Wrapping suspend members in `runCatching`
+ *
+ * Suspend members rethrow [kotlinx.coroutines.CancellationException] internally so
+ * structured cancellation propagates correctly. If you wrap a call in
+ * `runCatching { ... }` for resilience, rethrow `CancellationException` from your
+ * wrapper too — the standard `runCatching` catches every `Throwable`, including
+ * `CancellationException`, which silently swallows scope cancellation:
+ *
+ * ```
+ * val result = runCatching { billing.queryPurchases(params) }
+ *     .onFailure { if (it is kotlinx.coroutines.CancellationException) throw it }
+ * ```
+ *
+ * This is general kotlinx-coroutines hygiene (not billing-specific) but worth
+ * calling out because long-lived collectors of
+ * [BillingPurchaseUpdatesOwner.observePurchaseUpdates] and `runCatching`-wrapped
+ * `BillingActions` calls are the two most common sites where this footgun bites.
  */
 public interface BillingActions {
 
@@ -274,6 +292,81 @@ public interface BillingActions {
      * build [params] correctly under PBL 8's offer-token rules. For higher-level
      * orchestration (in-flight guard, watchdog, typed result), see
      * [com.kanetik.billing.ext.PurchaseFlowCoordinator].
+     *
+     * ## Dual throw-vs-event contract
+     *
+     * `launchFlow` has two outcome channels and consumers must wire up both:
+     *
+     * ### Synchronous-throw path
+     *
+     * Errors PBL knows about *before* showing the purchase sheet are surfaced as
+     * thrown [BillingException] subtypes from this call:
+     *  - [BillingException.DeveloperErrorException][com.kanetik.billing.exception.BillingException.DeveloperErrorException]
+     *    — [activity] is finishing or destroyed when the flow is launched
+     *    (the library checks `activity.isFinishing || activity.isDestroyed` and
+     *    rejects synthesizing a `DEVELOPER_ERROR` rather than calling into PBL
+     *    against an invalid window).
+     *  - [BillingException.ServiceUnavailableException][com.kanetik.billing.exception.BillingException.ServiceUnavailableException]
+     *    — wrapped from a `NullPointerException` thrown by
+     *    `BillingClient.launchBillingFlow` itself (typically the
+     *    `ProxyBillingActivity` null-`PendingIntent` crash).
+     *  - [BillingException.FatalErrorException][com.kanetik.billing.exception.BillingException.FatalErrorException]
+     *    — wrapped from any other unexpected `Exception` raised inside the
+     *    underlying call (synthesizes `BillingResponseCode.ERROR`).
+     *  - Any other [BillingException] subtype mapped from the
+     *    [com.android.billingclient.api.BillingResponseCode] returned
+     *    synchronously by `client.launchBillingFlow` itself — most notably
+     *    [BillingException.ItemAlreadyOwnedException][com.kanetik.billing.exception.BillingException.ItemAlreadyOwnedException]
+     *    when PBL knows the user owns the SKU without needing to render UI.
+     *
+     * ### Asynchronous-event path
+     *
+     * Outcomes that require Play to show UI (or wait for the user) arrive on
+     * [BillingPurchaseUpdatesOwner.observePurchaseUpdates] as
+     * [com.kanetik.billing.FlowOutcome] variants:
+     *  - [FlowOutcome.Pending][com.kanetik.billing.FlowOutcome.Pending]
+     *  - [FlowOutcome.Canceled][com.kanetik.billing.FlowOutcome.Canceled]
+     *  - [FlowOutcome.ItemAlreadyOwned][com.kanetik.billing.FlowOutcome.ItemAlreadyOwned]
+     *  - [FlowOutcome.ItemUnavailable][com.kanetik.billing.FlowOutcome.ItemUnavailable]
+     *  - [FlowOutcome.Failure][com.kanetik.billing.FlowOutcome.Failure]
+     *  - [FlowOutcome.UnknownResponse][com.kanetik.billing.FlowOutcome.UnknownResponse]
+     *
+     * Successful purchases arrive as [com.kanetik.billing.OwnedPurchases.Live]
+     * on the same stream.
+     *
+     * ### ⚠️ ITEM_ALREADY_OWNED is dual-path
+     *
+     * `ITEM_ALREADY_OWNED` can land on **either** channel depending on whether
+     * Play knows synchronously (no UI shown — thrown
+     * [ItemAlreadyOwnedException][com.kanetik.billing.exception.BillingException.ItemAlreadyOwnedException]
+     * here) or detects it asynchronously through `PurchasesUpdatedListener`
+     * (UI shown — emitted as [FlowOutcome.ItemAlreadyOwned][com.kanetik.billing.FlowOutcome.ItemAlreadyOwned]).
+     * Handle the same restore-entitlement flow in both places, e.g.:
+     *
+     * ```
+     * // Throw site (around the launchFlow call):
+     * try {
+     *     billing.launchFlow(activity, params)
+     * } catch (e: BillingException.ItemAlreadyOwnedException) {
+     *     restoreEntitlement()
+     * } catch (e: BillingException) {
+     *     showError(e.userFacingCategory)
+     * }
+     *
+     * // Event site (in your observePurchaseUpdates collector):
+     * when (event) {
+     *     is FlowOutcome.ItemAlreadyOwned -> restoreEntitlement()
+     *     // ...other branches
+     * }
+     * ```
+     *
+     * Missing either branch leaves "user already owns this" cases silently
+     * unhandled depending on Play's timing.
+     *
+     * @throws BillingException any synchronous failure as described above. As with
+     *   every other suspend member, [kotlinx.coroutines.CancellationException] is
+     *   rethrown internally and must propagate — see the class-level KDoc for the
+     *   `runCatching` wrapping rule.
      */
     @MainThread
     public suspend fun launchFlow(activity: Activity, params: BillingFlowParams)

--- a/billing/src/main/kotlin/com/kanetik/billing/BillingActions.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/BillingActions.kt
@@ -25,13 +25,21 @@ import com.kanetik.billing.exception.BillingException
  *
  * ## Wrapping suspend members for resilience
  *
- * Suspend members rethrow [kotlinx.coroutines.CancellationException] internally so
- * structured cancellation propagates correctly. If you wrap a call to absorb
- * non-billing failures (e.g. inside a long-lived collector that should not die
- * on a transient billing error), use an explicit `try/catch` that **rethrows**
- * `CancellationException` rather than `runCatching { ... }` — the standard
- * `runCatching` catches every `Throwable`, including `CancellationException`,
- * and silently swallows scope cancellation:
+ * Suspend members propagate **structured cancellation** correctly: a
+ * [kotlinx.coroutines.CancellationException] raised by the surrounding scope
+ * being torn down is rethrown so cancellation cascades. Internal `withTimeout`
+ * timeouts — which surface as
+ * [kotlinx.coroutines.TimeoutCancellationException], a `CancellationException`
+ * subclass — are intentionally converted into a [com.kanetik.billing.exception.BillingException]
+ * instead, since they represent a billing-layer failure rather than a scope
+ * teardown.
+ *
+ * If you wrap a call to absorb non-billing failures (e.g. inside a long-lived
+ * collector that should not die on a transient billing error), use an explicit
+ * `try/catch` that **rethrows** `CancellationException` rather than
+ * `runCatching { ... }` — the standard `runCatching` catches every
+ * `Throwable`, including `CancellationException`, and silently swallows scope
+ * cancellation:
  *
  * ```
  * try {

--- a/billing/src/main/kotlin/com/kanetik/billing/BillingActions.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/BillingActions.kt
@@ -52,9 +52,10 @@ import com.kanetik.billing.exception.BillingException
  * ```
  *
  * `Exception` (not `Throwable`) so JVM `Error`s — `OutOfMemoryError`,
- * `LinkageError`, etc. — propagate; the library's own catch chains in
- * [handlePurchase] follow the same rule and rethrow `VirtualMachineError`,
- * `LinkageError`, and `ThreadDeath` explicitly before any broad catch.
+ * `LinkageError`, etc. — propagate. (The library's own catch chains in
+ * [handlePurchase] go further: they catch `Throwable` for typed-result
+ * completeness, but rethrow `VirtualMachineError`, `LinkageError`, and
+ * `ThreadDeath` explicitly before any broad catch — same end result.)
  *
  * This is general kotlinx-coroutines hygiene (not billing-specific) but worth
  * calling out because long-lived collectors of
@@ -326,10 +327,10 @@ public interface BillingActions {
      * Errors PBL knows about *before* showing the purchase sheet are surfaced as
      * thrown [BillingException] subtypes from this call:
      *  - [BillingException.DeveloperErrorException][com.kanetik.billing.exception.BillingException.DeveloperErrorException]
-     *    — [activity] is finishing or destroyed when the flow is launched
-     *    (the library checks `activity.isFinishing || activity.isDestroyed` and
-     *    rejects synthesizing a `DEVELOPER_ERROR` rather than calling into PBL
-     *    against an invalid window).
+     *    — [activity] is finishing or destroyed when the flow is launched.
+     *    The library checks `activity.isFinishing || activity.isDestroyed`
+     *    and short-circuits with a synthesized `DEVELOPER_ERROR` rather than
+     *    calling into PBL against an invalid window.
      *  - [BillingException.ServiceUnavailableException][com.kanetik.billing.exception.BillingException.ServiceUnavailableException]
      *    — wrapped from a `NullPointerException` thrown by
      *    `BillingClient.launchBillingFlow` itself (typically the
@@ -387,10 +388,11 @@ public interface BillingActions {
      * Missing either branch leaves "user already owns this" cases silently
      * unhandled depending on Play's timing.
      *
-     * @throws BillingException any synchronous failure as described above. As with
-     *   every other suspend member, [kotlinx.coroutines.CancellationException] is
-     *   rethrown internally and must propagate — see the class-level KDoc for the
-     *   resilience-wrapping rule.
+     * @throws BillingException any synchronous failure as described above.
+     *   Parent-scope [kotlinx.coroutines.CancellationException] propagates
+     *   through unchanged; see the class-level KDoc for the
+     *   resilience-wrapping rule (and the `TimeoutCancellationException`
+     *   carve-out for internal connection timeouts).
      */
     @MainThread
     public suspend fun launchFlow(activity: Activity, params: BillingFlowParams)

--- a/billing/src/main/kotlin/com/kanetik/billing/BillingPurchaseUpdatesOwner.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/BillingPurchaseUpdatesOwner.kt
@@ -39,16 +39,16 @@ import kotlinx.coroutines.flow.Flow
  * channel split provides that, and exposing a single SharedFlow at the top would
  * collapse the distinction.
  *
- * ## Wrapping the collector in `runCatching`
+ * ## Wrapping the collector for resilience
  *
  * Long-lived collectors of this flow are the most common site for the
- * `runCatching`-swallows-cancellation footgun. If you wrap individual
- * emissions (or the collector body) in `runCatching { ... }` for resilience,
- * rethrow [kotlinx.coroutines.CancellationException] from your handler — the
- * standard `runCatching` catches every `Throwable`, including
- * `CancellationException`, and silently swallowing it leaves your collector
- * un-cancelable when its parent scope tears down. See
- * [BillingActions]'s class-level KDoc for the same note on suspend members.
+ * cancellation-swallowing footgun. If you wrap individual emissions (or the
+ * collector body) to absorb non-billing failures, use an explicit `try/catch`
+ * that **rethrows** [kotlinx.coroutines.CancellationException] rather than
+ * `runCatching { ... }` — the standard `runCatching` catches every
+ * `Throwable`, including `CancellationException`, and silently swallowing it
+ * leaves your collector un-cancelable when its parent scope tears down. See
+ * [BillingActions]'s class-level KDoc for the matching note on suspend members.
  */
 public interface BillingPurchaseUpdatesOwner {
 

--- a/billing/src/main/kotlin/com/kanetik/billing/BillingPurchaseUpdatesOwner.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/BillingPurchaseUpdatesOwner.kt
@@ -47,8 +47,9 @@ import kotlinx.coroutines.flow.Flow
  * that **rethrows** [kotlinx.coroutines.CancellationException] rather than
  * `runCatching { ... }` — the standard `runCatching` catches every
  * `Throwable`, including `CancellationException`, and silently swallowing it
- * leaves your collector un-cancelable when its parent scope tears down. See
- * [BillingActions]'s class-level KDoc for the matching note on suspend members.
+ * leaves your collector non-cancellable (its parent scope can no longer tear
+ * it down). See [BillingActions]'s class-level KDoc for the matching note on
+ * suspend members.
  */
 public interface BillingPurchaseUpdatesOwner {
 

--- a/billing/src/main/kotlin/com/kanetik/billing/BillingPurchaseUpdatesOwner.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/BillingPurchaseUpdatesOwner.kt
@@ -38,6 +38,17 @@ import kotlinx.coroutines.flow.Flow
  * can't express "replay-on-subscribe for some emissions but not others" — the
  * channel split provides that, and exposing a single SharedFlow at the top would
  * collapse the distinction.
+ *
+ * ## Wrapping the collector in `runCatching`
+ *
+ * Long-lived collectors of this flow are the most common site for the
+ * `runCatching`-swallows-cancellation footgun. If you wrap individual
+ * emissions (or the collector body) in `runCatching { ... }` for resilience,
+ * rethrow [kotlinx.coroutines.CancellationException] from your handler — the
+ * standard `runCatching` catches every `Throwable`, including
+ * `CancellationException`, and silently swallowing it leaves your collector
+ * un-cancelable when its parent scope tears down. See
+ * [BillingActions]'s class-level KDoc for the same note on suspend members.
  */
 public interface BillingPurchaseUpdatesOwner {
 

--- a/billing/src/main/kotlin/com/kanetik/billing/DefaultBillingRepository.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/DefaultBillingRepository.kt
@@ -177,6 +177,12 @@ internal class DefaultBillingRepository(
                 dispatcher = uiDispatcher,
                 maxAttempts = 1
             )
+        } catch (ce: kotlinx.coroutines.CancellationException) {
+            // Must come before the broad Exception catch below — otherwise a
+            // CancellationException raised by structured cancellation would get
+            // wrapped into a BillingException and silently break the scope teardown.
+            // Matches the rethrow contract every other suspend member upholds.
+            throw ce
         } catch (e: Exception) {
             // Re-throw the exception if it's already a BillingException, otherwise wrap it
             if (e !is BillingException) {

--- a/billing/src/test/kotlin/com/kanetik/billing/DefaultBillingRepositoryLaunchFlowCancellationTest.kt
+++ b/billing/src/test/kotlin/com/kanetik/billing/DefaultBillingRepositoryLaunchFlowCancellationTest.kt
@@ -1,0 +1,75 @@
+package com.kanetik.billing
+
+import android.app.Activity
+import com.android.billingclient.api.BillingFlowParams
+import com.google.common.truth.Truth.assertThat
+import com.kanetik.billing.exception.BillingException
+import com.kanetik.billing.logging.BillingLogger
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+/**
+ * Regression test for the launchFlow CE-rethrow fix surfaced by Copilot review of
+ * PR #19. The prior implementation's broad `catch (e: Exception)` would have wrapped
+ * a [kotlinx.coroutines.CancellationException] from parent-scope teardown into a
+ * [BillingException], silently breaking structured cancellation. The fix adds an
+ * explicit `catch (ce: CancellationException) { throw ce }` arm before the broad
+ * catch.
+ *
+ * If the fix regresses, this test fails because the cancelled coroutine surfaces a
+ * `BillingException` instead of letting CE propagate.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class DefaultBillingRepositoryLaunchFlowCancellationTest {
+
+    @Test
+    fun `launchFlow does not wrap parent-scope CancellationException into BillingException`() = runTest {
+        // A connection flow that never emits, so connectToClientAndCall suspends
+        // at .first() until either the 30s withTimeout fires (longer than this
+        // test runs in virtual time) or the parent scope is cancelled. The latter
+        // is what we want to trigger.
+        val neverEmittingFlow = MutableSharedFlow<InternalConnectionState>()
+        val storage = mockk<BillingClientStorage>(relaxed = true) {
+            every { connectionFlow } returns neverEmittingFlow.asSharedFlow()
+        }
+        val repo = DefaultBillingRepository(
+            billingClientStorage = storage,
+            logger = BillingLogger.Noop,
+            ioDispatcher = UnconfinedTestDispatcher(testScheduler),
+            uiDispatcher = UnconfinedTestDispatcher(testScheduler)
+        )
+        val activity = mockk<Activity>(relaxed = true) {
+            every { isFinishing } returns false
+            every { isDestroyed } returns false
+        }
+        val params = mockk<BillingFlowParams>(relaxed = true)
+
+        // Only catch BillingException — if the bug regresses, launchFlow wraps CE
+        // and we capture it here. With the fix, CE rethrows past this catch and
+        // ends the launch coroutine via cancellation, leaving `wrapped` null.
+        var wrapped: BillingException? = null
+        val job = launch(start = CoroutineStart.UNDISPATCHED) {
+            try {
+                repo.launchFlow(activity, params)
+            } catch (e: BillingException) {
+                wrapped = e
+            }
+        }
+        // Coroutine has now suspended at connectionFlow.first().
+        runCurrent()
+
+        job.cancel()
+        job.join()
+
+        assertThat(wrapped).isNull()
+    }
+}

--- a/billing/src/test/kotlin/com/kanetik/billing/DefaultBillingRepositoryLaunchFlowCancellationTest.kt
+++ b/billing/src/test/kotlin/com/kanetik/billing/DefaultBillingRepositoryLaunchFlowCancellationTest.kt
@@ -18,15 +18,14 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
 /**
- * Regression test for the launchFlow CE-rethrow fix surfaced by Copilot review of
- * PR #19. The prior implementation's broad `catch (e: Exception)` would have wrapped
- * a [kotlinx.coroutines.CancellationException] from parent-scope teardown into a
- * [BillingException], silently breaking structured cancellation. The fix adds an
- * explicit `catch (ce: CancellationException) { throw ce }` arm before the broad
- * catch.
- *
- * If the fix regresses, this test fails because the cancelled coroutine surfaces a
- * `BillingException` instead of letting CE propagate.
+ * Regression test for `DefaultBillingRepository.launchFlow`'s
+ * `CancellationException` contract: a `CancellationException` raised by
+ * parent-scope teardown must propagate untouched (not be wrapped into a
+ * `BillingException` by the broad `catch (e: Exception)` that handles the
+ * other `launchBillingFlow` failures). The launchFlow body has a dedicated
+ * `catch (ce: CancellationException) { throw ce }` arm before the broad
+ * catch; if it's removed or reordered, structured cancellation is silently
+ * broken when the surrounding scope tears down.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class DefaultBillingRepositoryLaunchFlowCancellationTest {


### PR DESCRIPTION
## Summary

Started as a docs-only correctness sweep against issues #15 and #17; review surfaced a real implementation bug in `DefaultBillingRepository.launchFlow` that was making one of the doc claims inaccurate, so this now ships both:

### Implementation fix

- **`DefaultBillingRepository.launchFlow` now propagates `CancellationException`.** The prior broad `catch (e: Exception)` would have wrapped a `CancellationException` into a `BillingException`, silently breaking structured cancellation when the surrounding scope was torn down. Added `catch (ce: CancellationException) { throw ce }` before the general wrapping so `launchFlow` upholds the same CE contract every other suspend member already follows (e.g. `BillingActions.handlePurchase`, line ~247).

### Documentation

- **`BillingActions` class-level KDoc + `BillingPurchaseUpdatesOwner.observePurchaseUpdates` KDoc** gain a "Wrapping suspend members for resilience" note. Suspend members rethrow CE internally so structured cancellation propagates, but `runCatching` catches every `Throwable` (including CE) and silently re-introduces the swallow-CE footgun. The note recommends explicit `try/catch` with a CE rethrow rather than `runCatching`. Long-lived collectors of `observePurchaseUpdates` are the most common site, so the warning is repeated there for visibility. Followed issue #15's "lower-effort alternative" path — no `runCatchingCancellable` helper. Closes #15.

- **`BillingActions.launchFlow` KDoc** expanded with the dual throw-vs-event contract: synchronous PBL errors surface as thrown `BillingException` subtypes (invalid activity → `DeveloperErrorException`, `NullPointerException` from `launchBillingFlow` → `ServiceUnavailableException`, other `Exception` → `FatalErrorException`, any non-`OK` `BillingResponseCode` returned synchronously — including `ITEM_ALREADY_OWNED` when PBL knows without showing UI). UI-mediated outcomes arrive on `observePurchaseUpdates` as `FlowOutcome` variants. `ITEM_ALREADY_OWNED` is called out as dual-path with an example covering both the `try/catch` around `launchFlow` and the `FlowOutcome.ItemAlreadyOwned` collector branch. Also tightens the return semantic — completion is "submitted to Play", not "UI rendered" (PBL exposes no UI-rendered signal). Closes #17.

### Resilience example

- The `try/catch` example in the resilience note narrows to `catch (e: Exception)` rather than `catch (e: Throwable)` to avoid swallowing JVM `Error`s (e.g. `OutOfMemoryError`, `LinkageError`). Added a one-paragraph footnote pointing readers at the library's own `handlePurchase` catch chain as the canonical example of how the library itself rethrows `VirtualMachineError`, `LinkageError`, and `ThreadDeath` before any broad catch.

## Test plan

- [x] `gradlew.bat :billing:compileDebugKotlin` succeeds
- [x] `gradlew.bat :billing:testDebugUnitTest` passes (no regressions; existing tests cover `BillingActions.handlePurchase` CE-rethrow path)
- [ ] CI green
- [ ] Spot-check rendered KDoc in IDE for the two interfaces

Closes #15
Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)