### PR TITLE
feat: ship SignedEntitlementStorage + HmacKeyProvider helpers (#16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`SignedEntitlementStorage` decorator + HMAC key-provider helpers for
+  tamper-resistant on-device persistence.** Wraps any existing
+  `EntitlementStorage` implementation, signs the snapshot on every write
+  (HMAC-SHA256 over a versioned canonical encoding), and verifies the
+  signature on read. Tampered or unsigned snapshots are dropped — the cache
+  reads them as cold-start and `OwnedPurchases.Live` re-confirms on next
+  launch. Closes the gap that previously kept freemium-with-real-value apps
+  from adopting `EntitlementCache`: the library now ships first-party
+  signing instead of telling consumers to roll their own. New public types,
+  all under `com.kanetik.billing.entitlement.signed`:
+
+  - `SignedEntitlementStorage` — the decorator. Includes a `TamperEvent`
+    callback (`MissingSignature` / `InvalidSignature` / `UnsupportedVersion`)
+    so consumers can route the common one-time post-upgrade case differently
+    from the strong tamper indicator in their telemetry. Includes a static
+    `migrateUnsignedSnapshot` helper for adopters who want to avoid the
+    one-time cold-start by trusting an existing snapshot once.
+  - `HmacKeyProvider` — interface; `sign(data) / verify(data, sig)` shape
+    so non-extractable Keystore keys are first-class.
+  - `KeystoreBackedKeyProvider` — Android Keystore-backed HMAC-SHA256, the
+    recommended default. Hardware-backed where available.
+  - `ServerSeededKeyProvider` — per-install seed fetched from a backend on
+    first use, cached locally. The default `SharedPreferencesSeedCache` is
+    plaintext; consumers needing real tamper resistance should prefer
+    `KeystoreBackedKeyProvider` (caveat documented on both types).
+  - `SignatureStore` / `SeedCache` interfaces with
+    `SharedPreferencesSignatureStore` / `SharedPreferencesSeedCache`
+    defaults. Consumers can swap either with their own backend (DataStore,
+    Room, encrypted prefs).
+
+  The signature wire format is `4-byte version || 32-byte HMAC-SHA256` over
+  a deterministic canonical encoding of `(version, snapshot)`. Versioned
+  signing means future field additions to `EntitlementSnapshot` won't
+  invalidate existing signatures — signed at v1 keeps verifying at v2 as
+  long as the new field is nullable / has a documented v1-default. (#16)
+
 ### Breaking
 
 - **`HandlePurchaseResult` sealed class gained a new `NotOwned` subtype.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `EntitlementStorage` implementation, signs the snapshot on every write
   (HMAC-SHA256 over a versioned canonical encoding), and verifies the
   signature on read. Tampered or unsigned snapshots are dropped — the cache
-  reads them as cold-start and `OwnedPurchases.Live` re-confirms on next
-  launch. Closes the gap that previously kept freemium-with-real-value apps
+  reads them as cold-start and the next `OwnedPurchases.Live` or
+  `OwnedPurchases.Recovered` re-confirms on next launch. Closes the gap that previously kept freemium-with-real-value apps
   from adopting `EntitlementCache`: the library now ships first-party
   signing instead of telling consumers to roll their own. New public types,
   all under `com.kanetik.billing.entitlement.signed`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (HMAC-SHA256 over a versioned canonical encoding), and verifies the
   signature on read. Tampered or unsigned snapshots are dropped — the cache
   reads them as cold-start and the next `OwnedPurchases.Live` or
-  `OwnedPurchases.Recovered` re-confirms on next launch. Closes the gap that previously kept freemium-with-real-value apps
+  `OwnedPurchases.Recovered` re-confirms truth (often within the same
+  launch, once the billing connection establishes). Closes the gap that previously kept freemium-with-real-value apps
   from adopting `EntitlementCache`: the library now ships first-party
   signing instead of telling consumers to roll their own. New public types,
   all under `com.kanetik.billing.entitlement.signed`:

--- a/README.md
+++ b/README.md
@@ -459,7 +459,53 @@ interface EntitlementStorage {
 
 `EntitlementSnapshot` is plain data: `(isEntitled: Boolean, confirmedAtMs: Long, purchaseToken: String?)`. The cache calls `read()` once on `start()` to hydrate, then `write()` on every entitlement-affecting transition. `InGrace` is **not** persisted — grace re-derives from the most recent confirmed `confirmedAtMs` on read, which keeps an attacker who can manipulate storage from extending the window indefinitely.
 
-If your threat model includes users tampering with on-device storage to extend entitlement (freemium apps where premium has real value), implement `read` / `write` against a signed-prefs layer keyed off a server-issued secret. The cache trusts what storage returns. For most apps the on-device storage is fine — a tampered snapshot gets overwritten the next time `OwnedPurchases.Live` or `OwnedPurchases.Recovered` confirms (or fails to confirm via `PurchaseRevoked`) the entitlement.
+For most apps the on-device storage is fine — a tampered snapshot gets overwritten the next time `OwnedPurchases.Live` or `OwnedPurchases.Recovered` confirms (or fails to confirm via `PurchaseRevoked`) the entitlement. The cache trusts what storage returns.
+
+### Tamper-resistant storage
+
+If your threat model includes users tampering with on-device storage to extend entitlement (freemium apps where premium has real value), wrap your `EntitlementStorage` in `SignedEntitlementStorage`. The decorator signs the snapshot on every write and verifies the signature on read; tampered snapshots are dropped (the cache reads them as cold-start and the next `OwnedPurchases.Live` re-confirms truth).
+
+```kotlin
+import com.kanetik.billing.entitlement.signed.*
+
+val storage: EntitlementStorage = SignedEntitlementStorage(
+    delegate = MyDataStoreEntitlementStorage(context),
+    keyProvider = KeystoreBackedKeyProvider.create(),
+    signatureStore = SharedPreferencesSignatureStore(context),
+    onTamperDetected = { event ->
+        when (event) {
+            TamperEvent.MissingSignature -> logger.info("First read after upgrade")
+            TamperEvent.InvalidSignature -> logger.warn("Possible tampering detected")
+            is TamperEvent.UnsupportedVersion -> logger.warn("Unknown sig version ${event.version}")
+        }
+    },
+)
+val cache = EntitlementCache(purchasesUpdates, storage, gracePolicy, productPredicate)
+```
+
+`SignedEntitlementStorage` keeps the library neutral on the persistence backend — the underlying `EntitlementStorage` still owns the snapshot bytes, the signature blob lives separately in `SignatureStore`. Pick `KeystoreBackedKeyProvider` (the recommended default; uses Android Keystore HMAC keys, hardware-backed where available) or `ServerSeededKeyProvider` (per-install seed from your backend, cached locally — see its KDoc for the plaintext-cache caveat). The library can't enforce key non-extractability and isn't a replacement for server-side validation; both caveats are documented on the relevant types.
+
+`onTamperDetected` distinguishes three cases via the `TamperEvent` sealed type. The most common one in practice is `MissingSignature` — fired the first time the decorator reads a snapshot that was written by a release without `SignedEntitlementStorage`. Treat it differently from `InvalidSignature` in your telemetry; the latter is the strong tamper indicator.
+
+#### Migrating an existing unsigned snapshot
+
+By default, the first read after wrapping an existing unsigned snapshot fires `TamperEvent.MissingSignature` and returns null — a one-time cold-start. The next `OwnedPurchases.Live` confirmation re-establishes truth and writes a signature on the transition. That's the secure default: no perpetual "delete the signature file to bypass" attack window.
+
+If you'd rather avoid the cold-start (UX over strict-from-day-one tamper resistance), call `SignedEntitlementStorage.migrateUnsignedSnapshot` once on first launch after upgrade, guarded by your own marker:
+
+```kotlin
+val rawStorage = MyDataStoreEntitlementStorage(context)
+val keyProvider = KeystoreBackedKeyProvider.create()
+val sigStore = SharedPreferencesSignatureStore(context)
+
+if (!prefs.getBoolean("entitlement_signed_migrated", false)) {
+    SignedEntitlementStorage.migrateUnsignedSnapshot(rawStorage, keyProvider, sigStore)
+    prefs.edit().putBoolean("entitlement_signed_migrated", true).apply()
+}
+val storage = SignedEntitlementStorage(rawStorage, keyProvider, sigStore, onTamperDetected = { ... })
+```
+
+Tradeoff: the helper trusts the existing snapshot once. If pre-upgrade tampering is in your threat model, skip the helper and accept the cold-start. The helper itself can't be made into a permanent decorator mode without leaving a "delete the sig file to re-trigger migration" backdoor — that's why it's a static one-shot guarded by consumer-side state.
 
 ### Wiring the connection
 

--- a/README.md
+++ b/README.md
@@ -463,7 +463,7 @@ For most apps the on-device storage is fine — a tampered snapshot gets overwri
 
 ### Tamper-resistant storage
 
-If your threat model includes users tampering with on-device storage to extend entitlement (freemium apps where premium has real value), wrap your `EntitlementStorage` in `SignedEntitlementStorage`. The decorator signs the snapshot on every write and verifies the signature on read; tampered snapshots are dropped (the cache reads them as cold-start and the next `OwnedPurchases.Live` re-confirms truth).
+If your threat model includes users tampering with on-device storage to extend entitlement (freemium apps where premium has real value), wrap your `EntitlementStorage` in `SignedEntitlementStorage`. The decorator signs the snapshot on every write and verifies the signature on read; tampered snapshots are dropped (the cache reads them as cold-start and the next `OwnedPurchases.Live` or `OwnedPurchases.Recovered` re-confirms truth).
 
 ```kotlin
 import com.kanetik.billing.entitlement.signed.*
@@ -489,7 +489,7 @@ val cache = EntitlementCache(purchasesUpdates, storage, gracePolicy, productPred
 
 #### Migrating an existing unsigned snapshot
 
-By default, the first read after wrapping an existing unsigned snapshot fires `TamperEvent.MissingSignature` and returns null — a one-time cold-start. The next `OwnedPurchases.Live` confirmation re-establishes truth and writes a signature on the transition. That's the secure default: no perpetual "delete the signature file to bypass" attack window.
+By default, the first read after wrapping an existing unsigned snapshot fires `TamperEvent.MissingSignature` and returns null — a one-time cold-start. The next `OwnedPurchases.Live` or `OwnedPurchases.Recovered` confirmation re-establishes truth and writes a signature on the transition. That's the secure default: no perpetual "delete the signature file to bypass" attack window.
 
 If you'd rather avoid the cold-start (UX over strict-from-day-one tamper resistance), call `SignedEntitlementStorage.migrateUnsignedSnapshot` once on first launch after upgrade, guarded by your own marker. `migrateUnsignedSnapshot` is `suspend`, so call it from a coroutine — and call it **before** constructing the `SignedEntitlementStorage` that wraps the same trio, so the cache's first read sees the signature you just wrote:
 

--- a/README.md
+++ b/README.md
@@ -491,18 +491,20 @@ val cache = EntitlementCache(purchasesUpdates, storage, gracePolicy, productPred
 
 By default, the first read after wrapping an existing unsigned snapshot fires `TamperEvent.MissingSignature` and returns null — a one-time cold-start. The next `OwnedPurchases.Live` confirmation re-establishes truth and writes a signature on the transition. That's the secure default: no perpetual "delete the signature file to bypass" attack window.
 
-If you'd rather avoid the cold-start (UX over strict-from-day-one tamper resistance), call `SignedEntitlementStorage.migrateUnsignedSnapshot` once on first launch after upgrade, guarded by your own marker:
+If you'd rather avoid the cold-start (UX over strict-from-day-one tamper resistance), call `SignedEntitlementStorage.migrateUnsignedSnapshot` once on first launch after upgrade, guarded by your own marker. `migrateUnsignedSnapshot` is `suspend`, so call it from a coroutine — and call it **before** constructing the `SignedEntitlementStorage` that wraps the same trio, so the cache's first read sees the signature you just wrote:
 
 ```kotlin
-val rawStorage = MyDataStoreEntitlementStorage(context)
-val keyProvider = KeystoreBackedKeyProvider.create()
-val sigStore = SharedPreferencesSignatureStore(context)
+suspend fun bootstrapEntitlementStorage(context: Context): EntitlementStorage {
+    val rawStorage = MyDataStoreEntitlementStorage(context)
+    val keyProvider = KeystoreBackedKeyProvider.create()
+    val sigStore = SharedPreferencesSignatureStore(context)
 
-if (!prefs.getBoolean("entitlement_signed_migrated", false)) {
-    SignedEntitlementStorage.migrateUnsignedSnapshot(rawStorage, keyProvider, sigStore)
-    prefs.edit().putBoolean("entitlement_signed_migrated", true).apply()
+    if (!prefs.getBoolean("entitlement_signed_migrated", false)) {
+        SignedEntitlementStorage.migrateUnsignedSnapshot(rawStorage, keyProvider, sigStore)
+        prefs.edit().putBoolean("entitlement_signed_migrated", true).apply()
+    }
+    return SignedEntitlementStorage(rawStorage, keyProvider, sigStore, onTamperDetected = { ... })
 }
-val storage = SignedEntitlementStorage(rawStorage, keyProvider, sigStore, onTamperDetected = { ... })
 ```
 
 Tradeoff: the helper trusts the existing snapshot once. If pre-upgrade tampering is in your threat model, skip the helper and accept the cold-start. The helper itself can't be made into a permanent decorator mode without leaving a "delete the sig file to re-trigger migration" backdoor — that's why it's a static one-shot guarded by consumer-side state.

--- a/billing/src/main/kotlin/com/kanetik/billing/entitlement/EntitlementStorage.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/entitlement/EntitlementStorage.kt
@@ -41,11 +41,15 @@ package com.kanetik.billing.entitlement
  *
  * ## Integrity
  *
- * If your threat model includes users tampering with on-device storage to
- * extend entitlement (e.g. a freemium app where premium has real value),
- * implement [write] / [read] against a signed-prefs layer keyed off a
- * server-issued secret. The [EntitlementSnapshot] type is plain data — no
- * built-in signature or HMAC; the cache trusts what storage returns.
+ * The [EntitlementSnapshot] type is plain data — no built-in signature or
+ * HMAC; the cache trusts what storage returns. If your threat model includes
+ * users tampering with on-device storage to extend entitlement (e.g. a
+ * freemium app where premium has real value), wrap your implementation in
+ * [com.kanetik.billing.entitlement.signed.SignedEntitlementStorage] — a
+ * decorator that signs the snapshot on write and verifies it on read using
+ * an HMAC key from a [com.kanetik.billing.entitlement.signed.HmacKeyProvider]
+ * (Android Keystore-backed by default). The decorator stays neutral on the
+ * persistence backend; you only have to wire up signing once.
  *
  * For most apps the on-device storage is fine — Play already enforces the
  * authoritative entitlement state on the next successful connect via

--- a/billing/src/main/kotlin/com/kanetik/billing/entitlement/EntitlementStorage.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/entitlement/EntitlementStorage.kt
@@ -48,7 +48,8 @@ package com.kanetik.billing.entitlement
  * [com.kanetik.billing.entitlement.signed.SignedEntitlementStorage] — a
  * decorator that signs the snapshot on write and verifies it on read using
  * an HMAC key from a [com.kanetik.billing.entitlement.signed.HmacKeyProvider]
- * (Android Keystore-backed by default). The decorator stays neutral on the
+ * (recommended default: [com.kanetik.billing.entitlement.signed.KeystoreBackedKeyProvider],
+ * which is Android Keystore-backed). The decorator stays neutral on the
  * persistence backend; you only have to wire up signing once.
  *
  * For most apps the on-device storage is fine — Play already enforces the

--- a/billing/src/main/kotlin/com/kanetik/billing/entitlement/signed/HmacKeyProvider.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/entitlement/signed/HmacKeyProvider.kt
@@ -1,0 +1,56 @@
+package com.kanetik.billing.entitlement.signed
+
+import java.security.MessageDigest
+
+/**
+ * Source of the HMAC key used by [SignedEntitlementStorage] to sign and
+ * verify [com.kanetik.billing.entitlement.EntitlementSnapshot] persistence.
+ *
+ * Implementations expose `sign` / `verify` rather than returning a raw key,
+ * so that providers backed by non-extractable hardware keys (Android Keystore
+ * with a hardware-backed `SecretKey`) can use the key without exposing it.
+ *
+ * # Threat-model caveats
+ *
+ *  - **The library cannot enforce key non-extractability.** A consumer who
+ *    hardcodes a key in `BuildConfig` and writes their own
+ *    `HmacKeyProvider` over it defeats the whole point of this layer. Use
+ *    [KeystoreBackedKeyProvider] (the easy-and-safe default) unless you have
+ *    a specific reason not to.
+ *  - **Not a replacement for server-side validation.** This provides
+ *    on-device tamper resistance. Apps with strong threat models still need a
+ *    backend purchase-validation pipeline (Voided Purchases API for one-time
+ *    products, RTDN for subscriptions).
+ *  - **Not a replacement for Tink.** This helper is scoped to
+ *    [com.kanetik.billing.entitlement.EntitlementStorage]. General-purpose
+ *    crypto is the consumer's concern.
+ *
+ * # Custom implementations
+ *
+ * Override [sign] and (optionally) [verify]. The default [verify] re-signs
+ * and constant-time-compares via [MessageDigest.isEqual]; that's correct for
+ * any deterministic HMAC, so most implementations only need [sign].
+ */
+public interface HmacKeyProvider {
+
+    /**
+     * Returns `HMAC(key, data)` for whichever key this provider holds.
+     *
+     * Must be deterministic for a given `(key, data)` pair — verification
+     * relies on byte-equal output. Implementations that need to lazily
+     * generate or fetch the key may suspend on first invocation; subsequent
+     * calls should be hot.
+     */
+    public suspend fun sign(data: ByteArray): ByteArray
+
+    /**
+     * Returns `true` iff [signature] equals `HMAC(key, data)`.
+     *
+     * Default: re-sign and compare in constant time. Override only if your
+     * provider has a faster verification path (rare).
+     */
+    public suspend fun verify(data: ByteArray, signature: ByteArray): Boolean {
+        val expected = sign(data)
+        return MessageDigest.isEqual(expected, signature)
+    }
+}

--- a/billing/src/main/kotlin/com/kanetik/billing/entitlement/signed/KeystoreBackedKeyProvider.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/entitlement/signed/KeystoreBackedKeyProvider.kt
@@ -1,0 +1,105 @@
+package com.kanetik.billing.entitlement.signed
+
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import java.security.KeyStore
+import javax.crypto.KeyGenerator
+import javax.crypto.Mac
+import javax.crypto.SecretKey
+
+/**
+ * [HmacKeyProvider] backed by an HMAC-SHA256 key stored in the Android
+ * Keystore. The recommended default for tamper-resistant on-device signing.
+ *
+ * On first sign / verify, generates a fresh `HmacSHA256` key with
+ * `PURPOSE_SIGN | PURPOSE_VERIFY` under [keyAlias] and persists it in the
+ * Keystore. Subsequent calls reuse the same key. Once generated, the key
+ * never leaves Keystore — [sign] uses [Mac.init] with the Keystore-backed
+ * [SecretKey], and the signing operation runs through the Keystore daemon.
+ *
+ * On devices with hardware-backed Keystore (most modern Android), the key is
+ * non-extractable: a rooted attacker cannot read it out of memory or pull it
+ * off disk. On devices without hardware-backed Keystore, the key is software
+ * protected only — better than nothing, but not unbreakable. The library
+ * does not enforce hardware backing; that's the OEM's call.
+ *
+ * # Key alias
+ *
+ * Defaults to [DEFAULT_KEY_ALIAS]. Override only if you have a reason
+ * (multiple independent caches in one app, separating dev/release keys,
+ * etc.). The alias is the identity of the key — losing it (uninstall, app
+ * data clear, factory reset) means existing signatures fail to verify, and
+ * the cache cold-starts on next launch.
+ *
+ * # Usage
+ *
+ * ```kotlin
+ * val keyProvider = KeystoreBackedKeyProvider.create()
+ * val storage = SignedEntitlementStorage(
+ *     delegate = myEntitlementStorage,
+ *     keyProvider = keyProvider,
+ *     signatureStore = SharedPreferencesSignatureStore(context),
+ * )
+ * ```
+ */
+public class KeystoreBackedKeyProvider private constructor(
+    private val keyAlias: String,
+) : HmacKeyProvider {
+
+    // Serialize key creation to avoid two parallel first-uses both calling
+    // KeyGenerator.generateKey() and racing on the alias.
+    private val keyMutex = Mutex()
+
+    @Volatile
+    private var cachedKey: SecretKey? = null
+
+    override suspend fun sign(data: ByteArray): ByteArray = withContext(Dispatchers.IO) {
+        val key = loadOrGenerateKey()
+        val mac = Mac.getInstance(MAC_ALGORITHM)
+        mac.init(key)
+        mac.doFinal(data)
+    }
+
+    private suspend fun loadOrGenerateKey(): SecretKey {
+        cachedKey?.let { return it }
+        return keyMutex.withLock {
+            cachedKey?.let { return@withLock it }
+
+            val keystore = KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
+            val existing = keystore.getKey(keyAlias, null) as? SecretKey
+            val key = existing ?: generateKey()
+            cachedKey = key
+            key
+        }
+    }
+
+    private fun generateKey(): SecretKey {
+        val generator = KeyGenerator.getInstance(MAC_ALGORITHM, ANDROID_KEYSTORE)
+        val spec = KeyGenParameterSpec.Builder(
+            keyAlias,
+            KeyProperties.PURPOSE_SIGN or KeyProperties.PURPOSE_VERIFY,
+        ).build()
+        generator.init(spec)
+        return generator.generateKey()
+    }
+
+    public companion object {
+        public const val DEFAULT_KEY_ALIAS: String =
+            "com.kanetik.billing.signed_entitlement.hmac_key"
+
+        private const val ANDROID_KEYSTORE = "AndroidKeyStore"
+        private const val MAC_ALGORITHM = "HmacSHA256"
+
+        /**
+         * Returns a provider for the named [keyAlias], lazily generating the
+         * Keystore entry on first sign / verify.
+         */
+        public fun create(
+            keyAlias: String = DEFAULT_KEY_ALIAS,
+        ): KeystoreBackedKeyProvider = KeystoreBackedKeyProvider(keyAlias)
+    }
+}

--- a/billing/src/main/kotlin/com/kanetik/billing/entitlement/signed/SeedCache.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/entitlement/signed/SeedCache.kt
@@ -1,0 +1,33 @@
+package com.kanetik.billing.entitlement.signed
+
+/**
+ * Persistence for the per-install seed used by [ServerSeededKeyProvider].
+ *
+ * The seed is fetched from a backend exactly once (on first sign / verify
+ * after install or cache miss) and cached locally for the lifetime of the
+ * install. This interface is the cache.
+ *
+ * Default implementation: [SharedPreferencesSeedCache]. Consumers can
+ * implement against any backend they prefer; the seed is opaque bytes.
+ *
+ * **Caveat:** the default cache stores the seed in plaintext. An attacker who
+ * can write to on-device storage to tamper with the snapshot can also extract
+ * the cached seed and forge fresh signatures, defeating the tamper resistance
+ * the seed is meant to provide. If your threat model requires hardware-backed
+ * protection, prefer [KeystoreBackedKeyProvider] over [ServerSeededKeyProvider]
+ * — the Keystore key is non-extractable on devices with hardware-backed
+ * Keystore. See [ServerSeededKeyProvider] for the full caveat discussion.
+ */
+public interface SeedCache {
+
+    /**
+     * Returns the cached seed bytes, or `null` if no seed has been cached
+     * yet (first run after install).
+     */
+    public suspend fun read(): ByteArray?
+
+    /**
+     * Persists [seed]. Must be atomic with respect to a subsequent [read].
+     */
+    public suspend fun write(seed: ByteArray)
+}

--- a/billing/src/main/kotlin/com/kanetik/billing/entitlement/signed/ServerSeededKeyProvider.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/entitlement/signed/ServerSeededKeyProvider.kt
@@ -1,0 +1,88 @@
+package com.kanetik.billing.entitlement.signed
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * [HmacKeyProvider] backed by a per-install seed fetched from a backend on
+ * first use, then cached locally via [SeedCache].
+ *
+ * Intended for consumers with auth infrastructure who want a key that's
+ * unique per install and revocable server-side (rotate the seed, invalidate
+ * all existing snapshots). The HMAC is computed in software over the cached
+ * seed using `HmacSHA256`.
+ *
+ * # Caveat: cached seed is local
+ *
+ * The seed is cached locally so that subsequent signs don't round-trip to
+ * the server. If the cache is plaintext (the default
+ * [SharedPreferencesSeedCache] is plaintext), an attacker with on-device
+ * write access — the same attacker the signing layer is meant to defend
+ * against — can extract the seed and forge fresh signatures. **In that
+ * threat model, this provider gives you no real tamper resistance.** Prefer
+ * [KeystoreBackedKeyProvider] if your devices have hardware-backed Keystore
+ * available.
+ *
+ * The provider is still useful when:
+ *  - The app does its own at-rest encryption around the seed cache and you
+ *    just want a clean abstraction over the per-install secret. (Wrap
+ *    [SeedCache] with your own encrypting decorator.)
+ *  - Server-side seed rotation is more important than tamper resistance per
+ *    se (e.g., revoke a compromised install on demand).
+ *  - You want to combine this provider with [KeystoreBackedKeyProvider] in
+ *    a layered scheme — but the library does not ship that layering today.
+ *
+ * # Fetcher contract
+ *
+ *  - [fetchSeed] is called at most once per install (until the cache is
+ *    cleared).
+ *  - Failures propagate. The caller of [sign] / [verify] receives whatever
+ *    the fetcher throws. Wrap with retries or fallback in your fetcher
+ *    implementation if you need that behaviour.
+ *  - The returned bytes are used as-is; the library does not derive,
+ *    truncate, or hash them. 32 random bytes is a reasonable seed size for
+ *    HMAC-SHA256.
+ *
+ * @param fetchSeed lambda invoked on first cache miss to obtain the seed
+ *   from a backend. Receives no arguments; the consumer's auth /
+ *   identification of the install is its responsibility.
+ * @param cache local persistence for the fetched seed. Default
+ *   [SharedPreferencesSeedCache] is plaintext; see caveat above.
+ */
+public class ServerSeededKeyProvider(
+    private val fetchSeed: suspend () -> ByteArray,
+    private val cache: SeedCache,
+) : HmacKeyProvider {
+
+    private val seedMutex = Mutex()
+
+    @Volatile
+    private var cachedSeed: ByteArray? = null
+
+    override suspend fun sign(data: ByteArray): ByteArray = withContext(Dispatchers.IO) {
+        val seed = loadOrFetchSeed()
+        val mac = Mac.getInstance(MAC_ALGORITHM)
+        mac.init(SecretKeySpec(seed, MAC_ALGORITHM))
+        mac.doFinal(data)
+    }
+
+    private suspend fun loadOrFetchSeed(): ByteArray {
+        cachedSeed?.let { return it }
+        return seedMutex.withLock {
+            cachedSeed?.let { return@withLock it }
+
+            val persisted = cache.read()
+            val seed = persisted ?: fetchSeed().also { cache.write(it) }
+            cachedSeed = seed
+            seed
+        }
+    }
+
+    private companion object {
+        const val MAC_ALGORITHM = "HmacSHA256"
+    }
+}

--- a/billing/src/main/kotlin/com/kanetik/billing/entitlement/signed/ServerSeededKeyProvider.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/entitlement/signed/ServerSeededKeyProvider.kt
@@ -75,8 +75,13 @@ public class ServerSeededKeyProvider(
         return seedMutex.withLock {
             cachedSeed?.let { return@withLock it }
 
-            val persisted = cache.read()
-            val seed = persisted ?: fetchSeed().also { cache.write(it) }
+            // Defensive copies on every boundary: a SeedCache impl might
+            // return its internal buffer (and later mutate it), and a
+            // fetchSeed lambda might do the same. The cached array must be
+            // owned by us, and the array we hand to cache.write must not be
+            // the same one we keep, so a cache impl mutating its input can't
+            // change the live key.
+            val seed = (cache.read()?.copyOf() ?: fetchSeed().copyOf().also { cache.write(it.copyOf()) })
             cachedSeed = seed
             seed
         }

--- a/billing/src/main/kotlin/com/kanetik/billing/entitlement/signed/SharedPreferencesSeedCache.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/entitlement/signed/SharedPreferencesSeedCache.kt
@@ -33,7 +33,21 @@ public class SharedPreferencesSeedCache(
 
     override suspend fun read(): ByteArray? = withContext(Dispatchers.IO) {
         val encoded = prefs.getString(KEY_SEED, null) ?: return@withContext null
-        runCatching { Base64.decode(encoded, Base64.NO_WRAP) }.getOrNull()
+        // Treat decode failure as corruption, not cache miss. Returning null
+        // here would let ServerSeededKeyProvider re-fetch a fresh seed,
+        // silently invalidating every signature that was written against the
+        // original seed — the same outcome an attacker corrupting the file
+        // would want. Throwing surfaces the corruption to the caller; they
+        // can decide whether to clear the cache and re-fetch deliberately or
+        // bail out. (Asymmetric with SharedPreferencesSignatureStore.read,
+        // which returns a shape-invalid blob — that path has the
+        // SignedEntitlementStorage size check downstream to convert it to
+        // InvalidSignature; the seed has no equivalent shape check.)
+        try {
+            Base64.decode(encoded, Base64.NO_WRAP)
+        } catch (e: IllegalArgumentException) {
+            throw IOException("Stored seed in SharedPreferences (file=$fileName) is not valid Base64; cache is corrupt.", e)
+        }
     }
 
     override suspend fun write(seed: ByteArray) {

--- a/billing/src/main/kotlin/com/kanetik/billing/entitlement/signed/SharedPreferencesSeedCache.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/entitlement/signed/SharedPreferencesSeedCache.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.Base64
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.io.IOException
 
 /**
  * Default [SeedCache] that persists the per-install seed in a private
@@ -38,7 +39,15 @@ public class SharedPreferencesSeedCache(
     override suspend fun write(seed: ByteArray) {
         withContext(Dispatchers.IO) {
             val encoded = Base64.encodeToString(seed, Base64.NO_WRAP)
-            prefs.edit().putString(KEY_SEED, encoded).commit()
+            // commit() reports false on a failed synchronous disk write. If we
+            // swallow that, ServerSeededKeyProvider may re-fetch on the next
+            // session (legitimate fetch), but worse, on the *current* session
+            // it caches a seed the next process can't see — so signatures
+            // written this session won't verify next session. Surface it.
+            val ok = prefs.edit().putString(KEY_SEED, encoded).commit()
+            if (!ok) {
+                throw IOException("Failed to persist seed to SharedPreferences (file=$fileName)")
+            }
         }
     }
 

--- a/billing/src/main/kotlin/com/kanetik/billing/entitlement/signed/SharedPreferencesSeedCache.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/entitlement/signed/SharedPreferencesSeedCache.kt
@@ -1,0 +1,51 @@
+package com.kanetik.billing.entitlement.signed
+
+import android.content.Context
+import android.util.Base64
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Default [SeedCache] that persists the per-install seed in a private
+ * SharedPreferences file.
+ *
+ * **The cached seed is plaintext.** An attacker with on-device write access
+ * can extract it and forge fresh signatures, defeating tamper resistance. Use
+ * [KeystoreBackedKeyProvider] instead if your threat model can rely on
+ * hardware-backed Keystore. See [ServerSeededKeyProvider] for the full
+ * discussion.
+ *
+ * @param context any [Context]; only `applicationContext` is retained.
+ * @param fileName SharedPreferences file name. Defaults to a stable
+ *   library-namespaced value.
+ */
+public class SharedPreferencesSeedCache(
+    context: Context,
+    private val fileName: String = DEFAULT_FILE_NAME,
+) : SeedCache {
+
+    private val appContext: Context = context.applicationContext
+
+    private val prefs by lazy {
+        appContext.getSharedPreferences(fileName, Context.MODE_PRIVATE)
+    }
+
+    override suspend fun read(): ByteArray? = withContext(Dispatchers.IO) {
+        val encoded = prefs.getString(KEY_SEED, null) ?: return@withContext null
+        runCatching { Base64.decode(encoded, Base64.NO_WRAP) }.getOrNull()
+    }
+
+    override suspend fun write(seed: ByteArray) {
+        withContext(Dispatchers.IO) {
+            val encoded = Base64.encodeToString(seed, Base64.NO_WRAP)
+            prefs.edit().putString(KEY_SEED, encoded).commit()
+        }
+    }
+
+    public companion object {
+        public const val DEFAULT_FILE_NAME: String =
+            "com.kanetik.billing.signed_entitlement.seed"
+
+        private const val KEY_SEED = "seed"
+    }
+}

--- a/billing/src/main/kotlin/com/kanetik/billing/entitlement/signed/SharedPreferencesSignatureStore.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/entitlement/signed/SharedPreferencesSignatureStore.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.Base64
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.io.IOException
 
 /**
  * Default [SignatureStore] that persists the signature blob in a private
@@ -32,13 +33,27 @@ public class SharedPreferencesSignatureStore(
 
     override suspend fun readSignature(): ByteArray? = withContext(Dispatchers.IO) {
         val encoded = prefs.getString(KEY_SIGNATURE, null) ?: return@withContext null
-        runCatching { Base64.decode(encoded, Base64.NO_WRAP) }.getOrNull()
+        // A non-decodable string means the prefs file is corrupt or someone
+        // tampered with the signature. Return an empty (and therefore
+        // shape-invalid) blob so SignedEntitlementStorage's size check fires
+        // InvalidSignature, not MissingSignature — surfacing this as
+        // "missing" would under-report tampering.
+        runCatching { Base64.decode(encoded, Base64.NO_WRAP) }.getOrDefault(ByteArray(0))
     }
 
     override suspend fun writeSignature(signature: ByteArray) {
         withContext(Dispatchers.IO) {
             val encoded = Base64.encodeToString(signature, Base64.NO_WRAP)
-            prefs.edit().putString(KEY_SIGNATURE, encoded).commit()
+            // commit() reports false when the synchronous disk write fails
+            // (storage full, permissions, etc.). Silently dropping that would
+            // violate SignatureStore's "atomic with respect to readSignature"
+            // contract — the next read would return a stale blob and verify
+            // against a fresh snapshot, surfacing as a false-positive
+            // InvalidSignature. Surface the failure instead.
+            val ok = prefs.edit().putString(KEY_SIGNATURE, encoded).commit()
+            if (!ok) {
+                throw IOException("Failed to persist signature to SharedPreferences (file=$fileName)")
+            }
         }
     }
 

--- a/billing/src/main/kotlin/com/kanetik/billing/entitlement/signed/SharedPreferencesSignatureStore.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/entitlement/signed/SharedPreferencesSignatureStore.kt
@@ -1,0 +1,51 @@
+package com.kanetik.billing.entitlement.signed
+
+import android.content.Context
+import android.util.Base64
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Default [SignatureStore] that persists the signature blob in a private
+ * SharedPreferences file.
+ *
+ * Bytes are stored as a base64 string (SharedPreferences doesn't support
+ * `byte[]` natively). I/O is wrapped in `withContext(Dispatchers.IO)` so
+ * callers can invoke [readSignature] / [writeSignature] from any dispatcher
+ * without blocking.
+ *
+ * @param context any [Context]; only `applicationContext` is retained.
+ * @param fileName SharedPreferences file name. Defaults to a stable
+ *   library-namespaced value. Override only if you have a reason to (multiple
+ *   independent caches in one app, test isolation, etc.).
+ */
+public class SharedPreferencesSignatureStore(
+    context: Context,
+    private val fileName: String = DEFAULT_FILE_NAME,
+) : SignatureStore {
+
+    private val appContext: Context = context.applicationContext
+
+    private val prefs by lazy {
+        appContext.getSharedPreferences(fileName, Context.MODE_PRIVATE)
+    }
+
+    override suspend fun readSignature(): ByteArray? = withContext(Dispatchers.IO) {
+        val encoded = prefs.getString(KEY_SIGNATURE, null) ?: return@withContext null
+        runCatching { Base64.decode(encoded, Base64.NO_WRAP) }.getOrNull()
+    }
+
+    override suspend fun writeSignature(signature: ByteArray) {
+        withContext(Dispatchers.IO) {
+            val encoded = Base64.encodeToString(signature, Base64.NO_WRAP)
+            prefs.edit().putString(KEY_SIGNATURE, encoded).commit()
+        }
+    }
+
+    public companion object {
+        public const val DEFAULT_FILE_NAME: String =
+            "com.kanetik.billing.signed_entitlement.signature"
+
+        private const val KEY_SIGNATURE = "signature"
+    }
+}

--- a/billing/src/main/kotlin/com/kanetik/billing/entitlement/signed/SignatureStore.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/entitlement/signed/SignatureStore.kt
@@ -1,0 +1,40 @@
+package com.kanetik.billing.entitlement.signed
+
+/**
+ * Persistence for the signature blob written alongside an
+ * [com.kanetik.billing.entitlement.EntitlementSnapshot].
+ *
+ * The blob is small — 4 bytes of version plus 32 bytes of HMAC-SHA256 (~36
+ * total). It must outlive process death and survive the same restarts that
+ * the snapshot itself does, so that
+ * [SignedEntitlementStorage.read] can verify the snapshot returned by the
+ * delegate.
+ *
+ * Default implementation: [SharedPreferencesSignatureStore]. Consumers with
+ * existing storage layers (DataStore, encrypted prefs, Room) can implement
+ * this interface against whatever backend they prefer; the library remains
+ * neutral on the persistence choice.
+ *
+ * Atomicity expectations match
+ * [com.kanetik.billing.entitlement.EntitlementStorage] — a successful
+ * [writeSignature] must be visible to the next process's [readSignature].
+ * Returning the signature for a *different* snapshot than the delegate
+ * returns is fine in steady state (the verification will fail, the read
+ * returns null, and the next live confirm restores) but should not be the
+ * common case; callers usually pair a single [SignatureStore] with a single
+ * delegate so writes interleave consistently.
+ */
+public interface SignatureStore {
+
+    /**
+     * Returns the most recently persisted signature blob, or `null` if none
+     * exists (first run, or the blob was cleared).
+     */
+    public suspend fun readSignature(): ByteArray?
+
+    /**
+     * Persists [signature]. Must be atomic with respect to a subsequent
+     * [readSignature] call.
+     */
+    public suspend fun writeSignature(signature: ByteArray)
+}

--- a/billing/src/main/kotlin/com/kanetik/billing/entitlement/signed/SignedEntitlementStorage.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/entitlement/signed/SignedEntitlementStorage.kt
@@ -1,0 +1,247 @@
+package com.kanetik.billing.entitlement.signed
+
+import com.kanetik.billing.entitlement.EntitlementSnapshot
+import com.kanetik.billing.entitlement.EntitlementStorage
+import java.nio.ByteBuffer
+
+/**
+ * [EntitlementStorage] decorator that signs the snapshot on write and
+ * verifies the signature on read, providing tamper resistance for the
+ * cache's persisted state.
+ *
+ * Wraps any other [EntitlementStorage] implementation (DataStore, Room,
+ * SharedPreferences, etc.). The library remains neutral on the persistence
+ * choice; only the signing is centralised. The wrapped [delegate] continues
+ * to own the snapshot bytes; the signature blob lives separately in
+ * [signatureStore].
+ *
+ * # Wire format
+ *
+ * The signature blob is `4 bytes version (BE int) || 32 bytes HMAC-SHA256`.
+ * The version is included both in the blob (so verification knows how to
+ * canonical-encode the snapshot) and inside the HMAC input (so it's
+ * authenticated and an attacker can't downgrade the version). See
+ * [SnapshotCanonicalBytes] for the per-version snapshot encoding and the
+ * procedure for adding a new version when [EntitlementSnapshot] grows a
+ * field.
+ *
+ * # Read path
+ *
+ * The decorator returns `null` (the cache reads it as "no prior state") in
+ * any of these cases, firing [onTamperDetected] with a typed [TamperEvent]:
+ *
+ *  - **[TamperEvent.MissingSignature]** — delegate returned a snapshot but
+ *    [signatureStore] is empty. Most likely benign: a one-time read after
+ *    upgrading from an unsigned configuration. Route this differently from
+ *    [TamperEvent.InvalidSignature] in your telemetry. See
+ *    [migrateUnsignedSnapshot] if you want to avoid the cold-start.
+ *  - **[TamperEvent.InvalidSignature]** — both pieces present, HMAC failed
+ *    to verify (or the blob was truncated). Strong tamper indicator; this
+ *    is the event your alerting should pay attention to.
+ *  - **[TamperEvent.UnsupportedVersion]** — blob declares a version this
+ *    build of the library doesn't know how to verify. Implies forgery, a
+ *    forward-incompatible blob written by a newer library version, or
+ *    storage corruption.
+ *
+ * If the delegate returns `null` (no prior snapshot at all), the decorator
+ * also returns `null` but does NOT fire [onTamperDetected] — that's the
+ * legitimate first-run case.
+ *
+ * # Write path
+ *
+ * `write` always writes the snapshot to the delegate first, then writes the
+ * signature blob. If the signature write fails after the snapshot write
+ * succeeded, the next read sees an unsigned snapshot and falls back to the
+ * cold-start path; `OwnedPurchases.Live` re-confirms on next launch.
+ *
+ * # Threat-model caveats
+ *
+ * See [HmacKeyProvider] for the full set. Briefly:
+ *
+ *  - The library cannot enforce key non-extractability. Use
+ *    [KeystoreBackedKeyProvider] (the easy default) unless you know what you're
+ *    doing.
+ *  - Not a replacement for server-side validation. The Voided Purchases API
+ *    and RTDN remain the right fit for stronger threat models.
+ *  - Not a replacement for Tink. This helper is scoped to [EntitlementStorage].
+ *
+ * # Example
+ *
+ * ```kotlin
+ * val storage: EntitlementStorage = SignedEntitlementStorage(
+ *     delegate = MyDataStoreEntitlementStorage(context),
+ *     keyProvider = KeystoreBackedKeyProvider.create(),
+ *     signatureStore = SharedPreferencesSignatureStore(context),
+ *     onTamperDetected = { event ->
+ *         when (event) {
+ *             TamperEvent.MissingSignature -> logger.info("First read after upgrade")
+ *             TamperEvent.InvalidSignature -> logger.warn("Possible tampering detected")
+ *             is TamperEvent.UnsupportedVersion ->
+ *                 logger.warn("Unknown signature version ${event.version}")
+ *         }
+ *     },
+ * )
+ * val cache = EntitlementCache(purchasesUpdates, storage, gracePolicy, productPredicate)
+ * ```
+ *
+ * @param delegate the underlying [EntitlementStorage] that holds the snapshot
+ *   bytes. Owns serialization; the decorator does not touch the snapshot
+ *   format the delegate uses.
+ * @param keyProvider source of the HMAC key. See [HmacKeyProvider].
+ * @param signatureStore persistence for the signature blob. See
+ *   [SignatureStore].
+ * @param onTamperDetected invoked from [read] when verification fails. Runs
+ *   on whatever dispatcher the read is invoked from. Intended for logging /
+ *   telemetry; do not throw.
+ */
+public class SignedEntitlementStorage(
+    private val delegate: EntitlementStorage,
+    private val keyProvider: HmacKeyProvider,
+    private val signatureStore: SignatureStore,
+    private val onTamperDetected: (TamperEvent) -> Unit = {},
+) : EntitlementStorage {
+
+    override suspend fun read(): EntitlementSnapshot? {
+        val snapshot = delegate.read() ?: return null
+
+        val blob = signatureStore.readSignature()
+        if (blob == null) {
+            onTamperDetected(TamperEvent.MissingSignature)
+            return null
+        }
+        if (blob.size < SIGNATURE_BLOB_SIZE) {
+            onTamperDetected(TamperEvent.InvalidSignature)
+            return null
+        }
+
+        val version = ByteBuffer.wrap(blob, 0, VERSION_PREFIX_SIZE).int
+        if (version > SnapshotCanonicalBytes.MAX_SUPPORTED_VERSION) {
+            onTamperDetected(TamperEvent.UnsupportedVersion(version))
+            return null
+        }
+
+        val canonical = SnapshotCanonicalBytes.encode(snapshot, version)
+        val hmac = blob.copyOfRange(VERSION_PREFIX_SIZE, blob.size)
+        val verified = keyProvider.verify(canonical, hmac)
+        if (!verified) {
+            onTamperDetected(TamperEvent.InvalidSignature)
+            return null
+        }
+        return snapshot
+    }
+
+    override suspend fun write(snapshot: EntitlementSnapshot) {
+        delegate.write(snapshot)
+        val blob = signSnapshot(snapshot, keyProvider)
+        signatureStore.writeSignature(blob)
+    }
+
+    public companion object {
+
+        /**
+         * Migrates an existing unsigned snapshot — typically left over from a
+         * release that didn't yet wrap [delegate] in [SignedEntitlementStorage]
+         * — by reading it once and writing a fresh signature blob via
+         * [signatureStore]. Subsequent reads through a normally-configured
+         * [SignedEntitlementStorage] over the same trio of dependencies will
+         * succeed without firing the tamper callback.
+         *
+         * Intended for one-shot use on first launch after upgrade. The caller
+         * is responsible for guarding with a "migration applied" marker (e.g.,
+         * a SharedPreferences boolean) so this runs at most once per install:
+         *
+         * ```kotlin
+         * if (!prefs.getBoolean("entitlement_signed_migrated", false)) {
+         *     SignedEntitlementStorage.migrateUnsignedSnapshot(
+         *         rawStorage, keyProvider, signatureStore,
+         *     )
+         *     prefs.edit().putBoolean("entitlement_signed_migrated", true).apply()
+         * }
+         * ```
+         *
+         * # Idempotency
+         *
+         * If [signatureStore] already contains a blob, this method does
+         * nothing and returns `false` — calling it more than once is safe.
+         *
+         * # Security tradeoff
+         *
+         * This trusts the existing snapshot. If the device was tampered with
+         * before this call ran, the resulting signature blesses the tampered
+         * data. Skip this helper and accept the cold-start path
+         * ([TamperEvent.MissingSignature] → null read → live re-confirm) if
+         * pre-upgrade tampering is in your threat model.
+         *
+         * @return `true` if a snapshot was found and a signature was written;
+         *   `false` if the delegate had no snapshot to migrate, or if a
+         *   signature already existed.
+         */
+        public suspend fun migrateUnsignedSnapshot(
+            delegate: EntitlementStorage,
+            keyProvider: HmacKeyProvider,
+            signatureStore: SignatureStore,
+        ): Boolean {
+            val snapshot = delegate.read() ?: return false
+            if (signatureStore.readSignature() != null) return false
+
+            val blob = signSnapshot(snapshot, keyProvider)
+            signatureStore.writeSignature(blob)
+            return true
+        }
+
+        private suspend fun signSnapshot(
+            snapshot: EntitlementSnapshot,
+            keyProvider: HmacKeyProvider,
+        ): ByteArray {
+            val version = SnapshotCanonicalBytes.CURRENT_VERSION
+            val canonical = SnapshotCanonicalBytes.encode(snapshot, version)
+            val hmac = keyProvider.sign(canonical)
+            val blob = ByteBuffer.allocate(VERSION_PREFIX_SIZE + hmac.size)
+            blob.putInt(version)
+            blob.put(hmac)
+            return blob.array()
+        }
+
+        private const val VERSION_PREFIX_SIZE = 4
+        private const val HMAC_SHA256_SIZE = 32
+        private const val SIGNATURE_BLOB_SIZE = VERSION_PREFIX_SIZE + HMAC_SHA256_SIZE
+    }
+}
+
+/**
+ * Reason that [SignedEntitlementStorage.read] couldn't return a valid
+ * snapshot. Passed to the `onTamperDetected` callback.
+ *
+ * Distinguishing these cases lets consumer telemetry route them differently:
+ * [MissingSignature] is usually benign (one-time migration), while
+ * [InvalidSignature] is the strong tamper indicator that should drive alerts.
+ */
+public sealed interface TamperEvent {
+
+    /**
+     * The delegate returned a snapshot, but [SignatureStore] held no
+     * signature. Typically a one-time first read after upgrading to signed
+     * storage from a release that wasn't wrapping its [EntitlementStorage].
+     * See [SignedEntitlementStorage.migrateUnsignedSnapshot] for an opt-in
+     * migration path that avoids this case.
+     */
+    public object MissingSignature : TamperEvent
+
+    /**
+     * The delegate returned a snapshot and the signature blob was present and
+     * the right shape, but HMAC verification failed. Strong tamper indicator
+     * — either the snapshot or the signature was modified after the last
+     * legitimate write. (Also fires if the blob is truncated below the
+     * minimum size; that's still consistent with a tamper attempt that
+     * corrupted the signature file.)
+     */
+    public object InvalidSignature : TamperEvent
+
+    /**
+     * The signature blob declared a version higher than this build of the
+     * library knows how to verify. Implies forgery, blob corruption, or a
+     * forward-incompatible blob written by a newer library version that
+     * downgraded.
+     */
+    public data class UnsupportedVersion(val version: Int) : TamperEvent
+}

--- a/billing/src/main/kotlin/com/kanetik/billing/entitlement/signed/SignedEntitlementStorage.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/entitlement/signed/SignedEntitlementStorage.kt
@@ -56,8 +56,8 @@ import java.nio.ByteBuffer
  * untouched — the next write retries from a consistent state. If the
  * signature write fails *after* the snapshot write succeeded, the next read
  * sees a snapshot/signature mismatch (or no signature on first ever write)
- * and falls back to the cold-start path; `OwnedPurchases.Live` re-confirms
- * on next launch.
+ * and falls back to the cold-start path; the next `OwnedPurchases.Live` or
+ * `OwnedPurchases.Recovered` re-confirms on next launch.
  *
  * # Threat-model caveats
  *

--- a/billing/src/main/kotlin/com/kanetik/billing/entitlement/signed/SignedEntitlementStorage.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/entitlement/signed/SignedEntitlementStorage.kt
@@ -49,10 +49,15 @@ import java.nio.ByteBuffer
  *
  * # Write path
  *
- * `write` always writes the snapshot to the delegate first, then writes the
- * signature blob. If the signature write fails after the snapshot write
- * succeeded, the next read sees an unsigned snapshot and falls back to the
- * cold-start path; `OwnedPurchases.Live` re-confirms on next launch.
+ * `write` computes the signature blob first (no side effects), then persists
+ * the snapshot via [delegate], then persists the signature via
+ * [signatureStore]. Ordering signing first means a [keyProvider] failure
+ * (e.g., transient Keystore key generation error) leaves both stores
+ * untouched — the next write retries from a consistent state. If the
+ * signature write fails *after* the snapshot write succeeded, the next read
+ * sees a snapshot/signature mismatch (or no signature on first ever write)
+ * and falls back to the cold-start path; `OwnedPurchases.Live` re-confirms
+ * on next launch.
  *
  * # Threat-model caveats
  *
@@ -135,8 +140,13 @@ public class SignedEntitlementStorage(
     }
 
     override suspend fun write(snapshot: EntitlementSnapshot) {
-        delegate.write(snapshot)
+        // Sign first (no side effects), then persist. A keyProvider failure —
+        // e.g., transient AndroidKeyStore key generation flake, ServerSeeded
+        // fetcher throwing — would otherwise leave delegate updated with a
+        // snapshot the next read can't verify. Computing the blob up front
+        // makes signing failures fully retriable.
         val blob = signSnapshot(snapshot, keyProvider)
+        delegate.write(snapshot)
         signatureStore.writeSignature(blob)
     }
 
@@ -271,10 +281,11 @@ public sealed interface TamperEvent {
     public object InvalidSignature : TamperEvent
 
     /**
-     * The signature blob declared a version higher than this build of the
-     * library knows how to verify. Implies forgery, blob corruption, or a
-     * forward-incompatible blob written by a newer library version that
-     * downgraded.
+     * The signature blob declared a version this build of the library can't
+     * verify (either above [SnapshotCanonicalBytes.MAX_SUPPORTED_VERSION] or
+     * below `1`). Implies forgery, blob corruption, or a forward-incompatible
+     * blob written by a newer library version that the app was later
+     * downgraded from.
      */
     public data class UnsupportedVersion(val version: Int) : TamperEvent
 }

--- a/billing/src/main/kotlin/com/kanetik/billing/entitlement/signed/SignedEntitlementStorage.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/entitlement/signed/SignedEntitlementStorage.kt
@@ -115,7 +115,7 @@ public class SignedEntitlementStorage(
         }
 
         val version = ByteBuffer.wrap(blob, 0, VERSION_PREFIX_SIZE).int
-        if (version > SnapshotCanonicalBytes.MAX_SUPPORTED_VERSION) {
+        if (version < MIN_VERSION || version > SnapshotCanonicalBytes.MAX_SUPPORTED_VERSION) {
             onTamperDetected(TamperEvent.UnsupportedVersion(version))
             return null
         }
@@ -148,14 +148,27 @@ public class SignedEntitlementStorage(
          *
          * Intended for one-shot use on first launch after upgrade. The caller
          * is responsible for guarding with a "migration applied" marker (e.g.,
-         * a SharedPreferences boolean) so this runs at most once per install:
+         * a SharedPreferences boolean) so this runs at most once per install.
+         * `migrateUnsignedSnapshot` is `suspend` (it reads and writes through
+         * the same dispatchers your storage normally uses), so call it from a
+         * coroutine — and call it **before** constructing the
+         * [SignedEntitlementStorage] that wraps the same trio, so the cache's
+         * first read sees the freshly-written signature instead of firing
+         * [TamperEvent.MissingSignature]:
          *
          * ```kotlin
-         * if (!prefs.getBoolean("entitlement_signed_migrated", false)) {
-         *     SignedEntitlementStorage.migrateUnsignedSnapshot(
-         *         rawStorage, keyProvider, signatureStore,
-         *     )
-         *     prefs.edit().putBoolean("entitlement_signed_migrated", true).apply()
+         * suspend fun bootstrapEntitlementStorage(): EntitlementStorage {
+         *     val rawStorage = MyDataStoreEntitlementStorage(context)
+         *     val keyProvider = KeystoreBackedKeyProvider.create()
+         *     val sigStore = SharedPreferencesSignatureStore(context)
+         *
+         *     if (!prefs.getBoolean("entitlement_signed_migrated", false)) {
+         *         SignedEntitlementStorage.migrateUnsignedSnapshot(
+         *             rawStorage, keyProvider, sigStore,
+         *         )
+         *         prefs.edit().putBoolean("entitlement_signed_migrated", true).apply()
+         *     }
+         *     return SignedEntitlementStorage(rawStorage, keyProvider, sigStore)
          * }
          * ```
          *
@@ -205,6 +218,11 @@ public class SignedEntitlementStorage(
         private const val VERSION_PREFIX_SIZE = 4
         private const val HMAC_SHA256_SIZE = 32
         private const val SIGNATURE_BLOB_SIZE = VERSION_PREFIX_SIZE + HMAC_SHA256_SIZE
+
+        // Lowest version this build will accept on read. SnapshotCanonicalBytes
+        // currently knows v1; allowing v0 or negatives would let a corrupted /
+        // forged blob crash read() via encode() throwing.
+        private const val MIN_VERSION = 1
     }
 }
 

--- a/billing/src/main/kotlin/com/kanetik/billing/entitlement/signed/SignedEntitlementStorage.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/entitlement/signed/SignedEntitlementStorage.kt
@@ -20,10 +20,10 @@ import java.nio.ByteBuffer
  * The signature blob is `4 bytes version (BE int) || 32 bytes HMAC-SHA256`.
  * The version is included both in the blob (so verification knows how to
  * canonical-encode the snapshot) and inside the HMAC input (so it's
- * authenticated and an attacker can't downgrade the version). See
- * [SnapshotCanonicalBytes] for the per-version snapshot encoding and the
- * procedure for adding a new version when [EntitlementSnapshot] grows a
- * field.
+ * authenticated and an attacker can't downgrade the version). The per-version
+ * snapshot canonical encoding is internal; the wire format is stable and
+ * versioned so future field additions to [EntitlementSnapshot] don't
+ * invalidate signatures written by older library versions.
  *
  * # Read path
  *
@@ -57,7 +57,8 @@ import java.nio.ByteBuffer
  * signature write fails *after* the snapshot write succeeded, the next read
  * sees a snapshot/signature mismatch (or no signature on first ever write)
  * and falls back to the cold-start path; the next `OwnedPurchases.Live` or
- * `OwnedPurchases.Recovered` re-confirms on next launch.
+ * `OwnedPurchases.Recovered` re-confirms truth (often within the same
+ * launch, once the billing connection establishes).
  *
  * # Threat-model caveats
  *
@@ -282,10 +283,10 @@ public sealed interface TamperEvent {
 
     /**
      * The signature blob declared a version this build of the library can't
-     * verify (either above [SnapshotCanonicalBytes.MAX_SUPPORTED_VERSION] or
-     * below `1`). Implies forgery, blob corruption, or a forward-incompatible
-     * blob written by a newer library version that the app was later
-     * downgraded from.
+     * verify (either above the highest version this build supports or below
+     * `1`). Implies forgery, blob corruption, or a forward-incompatible blob
+     * written by a newer library version that the app was later downgraded
+     * from.
      */
     public data class UnsupportedVersion(val version: Int) : TamperEvent
 }

--- a/billing/src/main/kotlin/com/kanetik/billing/entitlement/signed/SignedEntitlementStorage.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/entitlement/signed/SignedEntitlementStorage.kt
@@ -109,7 +109,11 @@ public class SignedEntitlementStorage(
             onTamperDetected(TamperEvent.MissingSignature)
             return null
         }
-        if (blob.size < SIGNATURE_BLOB_SIZE) {
+        // Wire format is fixed: VERSION_PREFIX_SIZE + HMAC_SHA256_SIZE = exactly
+        // SIGNATURE_BLOB_SIZE bytes. Anything else is malformed — including
+        // trailing bytes, which would otherwise be silently folded into the
+        // HMAC slice and verified against the wrong shape.
+        if (blob.size != SIGNATURE_BLOB_SIZE) {
             onTamperDetected(TamperEvent.InvalidSignature)
             return null
         }
@@ -194,8 +198,11 @@ public class SignedEntitlementStorage(
             keyProvider: HmacKeyProvider,
             signatureStore: SignatureStore,
         ): Boolean {
-            val snapshot = delegate.read() ?: return false
+            // Idempotent: skip the (potentially expensive) snapshot read when a
+            // signature is already in place. Repeated calls become a single
+            // signature read.
             if (signatureStore.readSignature() != null) return false
+            val snapshot = delegate.read() ?: return false
 
             val blob = signSnapshot(snapshot, keyProvider)
             signatureStore.writeSignature(blob)
@@ -209,7 +216,15 @@ public class SignedEntitlementStorage(
             val version = SnapshotCanonicalBytes.CURRENT_VERSION
             val canonical = SnapshotCanonicalBytes.encode(snapshot, version)
             val hmac = keyProvider.sign(canonical)
-            val blob = ByteBuffer.allocate(VERSION_PREFIX_SIZE + hmac.size)
+            // The wire format is anchored to HMAC-SHA256's 32-byte output; an
+            // HmacKeyProvider that returns a different size would silently
+            // produce blobs the reader doesn't define. Fail fast at the writer
+            // so a misconfigured custom provider surfaces as a contract
+            // violation rather than corrupt persistence.
+            require(hmac.size == HMAC_SHA256_SIZE) {
+                "HmacKeyProvider produced ${hmac.size}-byte signature; expected $HMAC_SHA256_SIZE (HMAC-SHA256)"
+            }
+            val blob = ByteBuffer.allocate(SIGNATURE_BLOB_SIZE)
             blob.putInt(version)
             blob.put(hmac)
             return blob.array()

--- a/billing/src/main/kotlin/com/kanetik/billing/entitlement/signed/SnapshotCanonicalBytes.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/entitlement/signed/SnapshotCanonicalBytes.kt
@@ -1,0 +1,87 @@
+package com.kanetik.billing.entitlement.signed
+
+import com.kanetik.billing.entitlement.EntitlementSnapshot
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+
+/**
+ * Internal helper: deterministic byte encoding of an [EntitlementSnapshot]
+ * tagged with a schema version, used as the input to HMAC sign / verify.
+ *
+ * # Wire format (v1)
+ * ```
+ * canonical_v1 := version_be(4 bytes)
+ *              || is_entitled(1 byte: 0 or 1)
+ *              || confirmed_at_ms(8 bytes BE long)
+ *              || token_len(4 bytes BE int; -1 for null)
+ *              || token_utf8(token_len bytes; absent when token_len == -1)
+ * ```
+ *
+ * The version int is part of the bytes the HMAC authenticates (not just a
+ * separately-stored prefix), so an attacker can't downgrade a v2 signature
+ * to v1 or vice versa without breaking verification.
+ *
+ * # Adding a field to [EntitlementSnapshot]
+ *
+ * 1. Add the field to [EntitlementSnapshot] (must be nullable or have a
+ *    documented absent-default consistent with v1 reads — additive evolution
+ *    only, no breaking shape changes).
+ * 2. Bump [CURRENT_VERSION] (e.g., 1 → 2).
+ * 3. Add a `2 -> ...` branch to [encode] that writes the new field.
+ * 4. Leave the `1 -> ...` branch untouched. It keeps verifying old signatures
+ *    by canonical-encoding only the v1-known fields. A snapshot that was
+ *    signed at v1 will continue to verify after the library upgrade because
+ *    the deserialized snapshot's new field defaults to its absent-value, which
+ *    the v1 encoder ignores.
+ * 5. Add a roundtrip test: sign at v1, read back through v2 code, verify still
+ *    passes. Sign at v2, verify v2.
+ *
+ * The verifier does not own snapshot deserialization (the consumer's
+ * [com.kanetik.billing.entitlement.EntitlementStorage] does). It receives the
+ * current-shape snapshot from the delegate and re-derives canonical bytes for
+ * whatever version the persisted signature blob declares.
+ */
+internal object SnapshotCanonicalBytes {
+
+    /**
+     * The version stamped into all newly-written signatures. Bump when adding
+     * a field to [EntitlementSnapshot]; see the file-level KDoc.
+     */
+    const val CURRENT_VERSION: Int = 1
+
+    /** Largest version this build of the library knows how to verify. */
+    const val MAX_SUPPORTED_VERSION: Int = CURRENT_VERSION
+
+    /**
+     * Encodes [snapshot] for signing at the named [version].
+     *
+     * @throws IllegalArgumentException if [version] is unknown to this build.
+     *   Callers verifying a persisted signature should range-check the parsed
+     *   version against [MAX_SUPPORTED_VERSION] before invoking and surface a
+     *   tamper / unsupported-version event instead of letting this throw.
+     */
+    fun encode(snapshot: EntitlementSnapshot, version: Int): ByteArray {
+        return when (version) {
+            1 -> encodeV1(snapshot)
+            else -> throw IllegalArgumentException("Unknown snapshot version: $version")
+        }
+    }
+
+    private fun encodeV1(snapshot: EntitlementSnapshot): ByteArray {
+        val tokenBytes: ByteArray? = snapshot.purchaseToken?.toByteArray(StandardCharsets.UTF_8)
+        val tokenLen = tokenBytes?.size ?: -1
+        val tokenSerializedSize = tokenBytes?.size ?: 0
+
+        // 4 (version) + 1 (isEntitled) + 8 (confirmedAtMs) + 4 (tokenLen) + tokenBytes
+        val totalSize = 4 + 1 + 8 + 4 + tokenSerializedSize
+        val buffer = ByteBuffer.allocate(totalSize)
+        buffer.putInt(1)
+        buffer.put(if (snapshot.isEntitled) 1.toByte() else 0.toByte())
+        buffer.putLong(snapshot.confirmedAtMs)
+        buffer.putInt(tokenLen)
+        if (tokenBytes != null) {
+            buffer.put(tokenBytes)
+        }
+        return buffer.array()
+    }
+}

--- a/billing/src/test/kotlin/com/kanetik/billing/entitlement/signed/ServerSeededKeyProviderTest.kt
+++ b/billing/src/test/kotlin/com/kanetik/billing/entitlement/signed/ServerSeededKeyProviderTest.kt
@@ -75,6 +75,39 @@ class ServerSeededKeyProviderTest {
     }
 
     @Test
+    fun `mutating bytes returned by fetchSeed does not affect cached key`() = runTest {
+        val mutableSeed = ByteArray(32) { 0x33 }
+        val provider = ServerSeededKeyProvider(
+            fetchSeed = { mutableSeed },
+            cache = InMemorySeedCache(),
+        )
+        val data = "payload".toByteArray()
+        val sigBefore = provider.sign(data)
+
+        // Caller mutates the seed they handed us. We should have copied it.
+        mutableSeed.fill(0x00)
+
+        val sigAfter = provider.sign(data)
+        assertThat(sigAfter).isEqualTo(sigBefore)
+    }
+
+    @Test
+    fun `mutating cache contents after sign does not affect cached key`() = runTest {
+        val cache = InMemorySeedCache().also { it.cached = ByteArray(32) { 0x44 } }
+        val provider = ServerSeededKeyProvider(
+            fetchSeed = { error("should not fetch") },
+            cache = cache,
+        )
+        val data = "payload".toByteArray()
+        val sigBefore = provider.sign(data)
+
+        cache.cached!!.fill(0x00)
+
+        val sigAfter = provider.sign(data)
+        assertThat(sigAfter).isEqualTo(sigBefore)
+    }
+
+    @Test
     fun `fetched seed is persisted to cache for subsequent sessions`() = runTest {
         val cache = InMemorySeedCache()
         val provider = ServerSeededKeyProvider(

--- a/billing/src/test/kotlin/com/kanetik/billing/entitlement/signed/ServerSeededKeyProviderTest.kt
+++ b/billing/src/test/kotlin/com/kanetik/billing/entitlement/signed/ServerSeededKeyProviderTest.kt
@@ -1,0 +1,99 @@
+package com.kanetik.billing.entitlement.signed
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import java.util.concurrent.atomic.AtomicInteger
+
+class ServerSeededKeyProviderTest {
+
+    @Test
+    fun `fetchSeed invoked exactly once across multiple sign calls`() = runTest {
+        val callCount = AtomicInteger(0)
+        val cache = InMemorySeedCache()
+        val provider = ServerSeededKeyProvider(
+            fetchSeed = {
+                callCount.incrementAndGet()
+                ByteArray(32) { 0x42 }
+            },
+            cache = cache,
+        )
+
+        provider.sign("first".toByteArray())
+        provider.sign("second".toByteArray())
+        provider.sign("third".toByteArray())
+
+        assertThat(callCount.get()).isEqualTo(1)
+    }
+
+    @Test
+    fun `existing cached seed prevents fetch from running`() = runTest {
+        val callCount = AtomicInteger(0)
+        val cache = InMemorySeedCache().also { it.cached = ByteArray(32) { 0x11 } }
+        val provider = ServerSeededKeyProvider(
+            fetchSeed = {
+                callCount.incrementAndGet()
+                ByteArray(32) { 0x42 }
+            },
+            cache = cache,
+        )
+
+        provider.sign("data".toByteArray())
+
+        assertThat(callCount.get()).isEqualTo(0)
+    }
+
+    @Test
+    fun `verify returns true for matching signature, false for tampered`() = runTest {
+        val provider = ServerSeededKeyProvider(
+            fetchSeed = { ByteArray(32) { it.toByte() } },
+            cache = InMemorySeedCache(),
+        )
+        val data = "payload".toByteArray()
+        val sig = provider.sign(data)
+
+        assertThat(provider.verify(data, sig)).isTrue()
+
+        val tampered = sig.copyOf().also { it[it.size - 1] = (it[it.size - 1].toInt() xor 0x01).toByte() }
+        assertThat(provider.verify(data, tampered)).isFalse()
+    }
+
+    @Test
+    fun `different seeds produce different signatures for the same input`() = runTest {
+        val data = "payload".toByteArray()
+
+        val seedA = ServerSeededKeyProvider(
+            fetchSeed = { ByteArray(32) { 0x01 } },
+            cache = InMemorySeedCache(),
+        )
+        val seedB = ServerSeededKeyProvider(
+            fetchSeed = { ByteArray(32) { 0x02 } },
+            cache = InMemorySeedCache(),
+        )
+
+        assertThat(seedA.sign(data)).isNotEqualTo(seedB.sign(data))
+    }
+
+    @Test
+    fun `fetched seed is persisted to cache for subsequent sessions`() = runTest {
+        val cache = InMemorySeedCache()
+        val provider = ServerSeededKeyProvider(
+            fetchSeed = { ByteArray(32) { 0x55 } },
+            cache = cache,
+        )
+
+        provider.sign("data".toByteArray())
+
+        assertThat(cache.cached).isEqualTo(ByteArray(32) { 0x55 })
+    }
+}
+
+private class InMemorySeedCache : SeedCache {
+    var cached: ByteArray? = null
+
+    override suspend fun read(): ByteArray? = cached
+
+    override suspend fun write(seed: ByteArray) {
+        cached = seed
+    }
+}

--- a/billing/src/test/kotlin/com/kanetik/billing/entitlement/signed/SignedEntitlementStorageTest.kt
+++ b/billing/src/test/kotlin/com/kanetik/billing/entitlement/signed/SignedEntitlementStorageTest.kt
@@ -1,0 +1,201 @@
+package com.kanetik.billing.entitlement.signed
+
+import com.google.common.truth.Truth.assertThat
+import com.kanetik.billing.entitlement.EntitlementSnapshot
+import com.kanetik.billing.entitlement.EntitlementStorage
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import java.nio.ByteBuffer
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+class SignedEntitlementStorageTest {
+
+    private val sampleSnapshot = EntitlementSnapshot(
+        isEntitled = true,
+        confirmedAtMs = 1_700_000_000_000L,
+        purchaseToken = "tok-1",
+    )
+
+    @Test
+    fun `write then read roundtrips the same snapshot`() = runTest {
+        val (storage, delegate, sigStore) = newStorage()
+
+        storage.write(sampleSnapshot)
+
+        assertThat(delegate.lastWritten).isEqualTo(sampleSnapshot)
+        assertThat(sigStore.last).isNotNull()
+        assertThat(storage.read()).isEqualTo(sampleSnapshot)
+    }
+
+    @Test
+    fun `read returns null without firing callback when delegate has no snapshot`() = runTest {
+        val tamperEvents = mutableListOf<TamperEvent>()
+        val (storage, _, _) = newStorage(onTamperDetected = { tamperEvents += it })
+
+        assertThat(storage.read()).isNull()
+        assertThat(tamperEvents).isEmpty()
+    }
+
+    @Test
+    fun `read fires MissingSignature when snapshot present but signature missing`() = runTest {
+        val tamperEvents = mutableListOf<TamperEvent>()
+        val (storage, delegate, _) = newStorage(onTamperDetected = { tamperEvents += it })
+
+        delegate.lastWritten = sampleSnapshot
+
+        assertThat(storage.read()).isNull()
+        assertThat(tamperEvents).containsExactly(TamperEvent.MissingSignature)
+    }
+
+    @Test
+    fun `read fires InvalidSignature when snapshot mutated after signing`() = runTest {
+        val tamperEvents = mutableListOf<TamperEvent>()
+        val (storage, delegate, _) = newStorage(onTamperDetected = { tamperEvents += it })
+
+        storage.write(sampleSnapshot)
+        delegate.lastWritten = sampleSnapshot.copy(isEntitled = false)
+
+        assertThat(storage.read()).isNull()
+        assertThat(tamperEvents).containsExactly(TamperEvent.InvalidSignature)
+    }
+
+    @Test
+    fun `read fires InvalidSignature when signature byte mutated`() = runTest {
+        val tamperEvents = mutableListOf<TamperEvent>()
+        val (storage, _, sigStore) = newStorage(onTamperDetected = { tamperEvents += it })
+
+        storage.write(sampleSnapshot)
+        val mutated = sigStore.last!!.copyOf()
+        mutated[mutated.size - 1] = (mutated[mutated.size - 1].toInt() xor 0xff).toByte()
+        sigStore.last = mutated
+
+        assertThat(storage.read()).isNull()
+        assertThat(tamperEvents).containsExactly(TamperEvent.InvalidSignature)
+    }
+
+    @Test
+    fun `read fires UnsupportedVersion when blob declares version above MAX_SUPPORTED_VERSION`() = runTest {
+        val tamperEvents = mutableListOf<TamperEvent>()
+        val (storage, _, sigStore) = newStorage(onTamperDetected = { tamperEvents += it })
+
+        storage.write(sampleSnapshot)
+        val futureBlob = ByteBuffer.allocate(36).apply {
+            putInt(SnapshotCanonicalBytes.MAX_SUPPORTED_VERSION + 1)
+            put(sigStore.last!!.copyOfRange(4, 36))
+        }.array()
+        sigStore.last = futureBlob
+
+        assertThat(storage.read()).isNull()
+        assertThat(tamperEvents).containsExactly(
+            TamperEvent.UnsupportedVersion(SnapshotCanonicalBytes.MAX_SUPPORTED_VERSION + 1),
+        )
+    }
+
+    @Test
+    fun `read fires InvalidSignature when blob is truncated below minimum size`() = runTest {
+        val tamperEvents = mutableListOf<TamperEvent>()
+        val (storage, _, sigStore) = newStorage(onTamperDetected = { tamperEvents += it })
+
+        storage.write(sampleSnapshot)
+        sigStore.last = sigStore.last!!.copyOfRange(0, 10)
+
+        assertThat(storage.read()).isNull()
+        assertThat(tamperEvents).containsExactly(TamperEvent.InvalidSignature)
+    }
+
+    @Test
+    fun `migrateUnsignedSnapshot returns false when delegate has no snapshot`() = runTest {
+        val delegate = InMemoryStorage()
+        val sigStore = InMemorySignatureStore()
+        val keyProvider = FixedKeyHmacProvider(KEY_BYTES)
+
+        val migrated = SignedEntitlementStorage.migrateUnsignedSnapshot(delegate, keyProvider, sigStore)
+
+        assertThat(migrated).isFalse()
+        assertThat(sigStore.last).isNull()
+    }
+
+    @Test
+    fun `migrateUnsignedSnapshot signs existing snapshot and subsequent reads succeed without callback`() = runTest {
+        val delegate = InMemoryStorage().also { it.lastWritten = sampleSnapshot }
+        val sigStore = InMemorySignatureStore()
+        val keyProvider = FixedKeyHmacProvider(KEY_BYTES)
+        val tamperEvents = mutableListOf<TamperEvent>()
+
+        val migrated = SignedEntitlementStorage.migrateUnsignedSnapshot(delegate, keyProvider, sigStore)
+        assertThat(migrated).isTrue()
+        assertThat(sigStore.last).isNotNull()
+
+        val storage = SignedEntitlementStorage(
+            delegate, keyProvider, sigStore,
+            onTamperDetected = { tamperEvents += it },
+        )
+        assertThat(storage.read()).isEqualTo(sampleSnapshot)
+        assertThat(tamperEvents).isEmpty()
+    }
+
+    @Test
+    fun `migrateUnsignedSnapshot is a no-op when signature already present`() = runTest {
+        val (storage, _, sigStore) = newStorage()
+        storage.write(sampleSnapshot)
+        val firstBlob = sigStore.last!!.copyOf()
+
+        val migrated = SignedEntitlementStorage.migrateUnsignedSnapshot(
+            delegate = storage, // re-using through the decorator is fine; delegate.read returns the same snapshot
+            keyProvider = FixedKeyHmacProvider(KEY_BYTES),
+            signatureStore = sigStore,
+        )
+
+        assertThat(migrated).isFalse()
+        assertThat(sigStore.last).isEqualTo(firstBlob)
+    }
+
+    // -- helpers -----------------------------------------------------------
+
+    private fun newStorage(
+        onTamperDetected: (TamperEvent) -> Unit = {},
+    ): Triple<SignedEntitlementStorage, InMemoryStorage, InMemorySignatureStore> {
+        val delegate = InMemoryStorage()
+        val sigStore = InMemorySignatureStore()
+        val storage = SignedEntitlementStorage(
+            delegate = delegate,
+            keyProvider = FixedKeyHmacProvider(KEY_BYTES),
+            signatureStore = sigStore,
+            onTamperDetected = onTamperDetected,
+        )
+        return Triple(storage, delegate, sigStore)
+    }
+
+    private companion object {
+        private val KEY_BYTES: ByteArray = ByteArray(32) { (it * 7 + 1).toByte() }
+    }
+}
+
+private class InMemoryStorage : EntitlementStorage {
+    var lastWritten: EntitlementSnapshot? = null
+
+    override suspend fun read(): EntitlementSnapshot? = lastWritten
+
+    override suspend fun write(snapshot: EntitlementSnapshot) {
+        lastWritten = snapshot
+    }
+}
+
+private class InMemorySignatureStore : SignatureStore {
+    var last: ByteArray? = null
+
+    override suspend fun readSignature(): ByteArray? = last
+
+    override suspend fun writeSignature(signature: ByteArray) {
+        last = signature
+    }
+}
+
+private class FixedKeyHmacProvider(private val key: ByteArray) : HmacKeyProvider {
+    override suspend fun sign(data: ByteArray): ByteArray {
+        val mac = Mac.getInstance("HmacSHA256")
+        mac.init(SecretKeySpec(key, "HmacSHA256"))
+        return mac.doFinal(data)
+    }
+}

--- a/billing/src/test/kotlin/com/kanetik/billing/entitlement/signed/SignedEntitlementStorageTest.kt
+++ b/billing/src/test/kotlin/com/kanetik/billing/entitlement/signed/SignedEntitlementStorageTest.kt
@@ -93,6 +93,38 @@ class SignedEntitlementStorageTest {
     }
 
     @Test
+    fun `read fires UnsupportedVersion when blob declares version 0`() = runTest {
+        val tamperEvents = mutableListOf<TamperEvent>()
+        val (storage, _, sigStore) = newStorage(onTamperDetected = { tamperEvents += it })
+
+        storage.write(sampleSnapshot)
+        val zeroVersionBlob = ByteBuffer.allocate(36).apply {
+            putInt(0)
+            put(sigStore.last!!.copyOfRange(4, 36))
+        }.array()
+        sigStore.last = zeroVersionBlob
+
+        assertThat(storage.read()).isNull()
+        assertThat(tamperEvents).containsExactly(TamperEvent.UnsupportedVersion(0))
+    }
+
+    @Test
+    fun `read fires UnsupportedVersion when blob declares negative version`() = runTest {
+        val tamperEvents = mutableListOf<TamperEvent>()
+        val (storage, _, sigStore) = newStorage(onTamperDetected = { tamperEvents += it })
+
+        storage.write(sampleSnapshot)
+        val negativeVersionBlob = ByteBuffer.allocate(36).apply {
+            putInt(-1)
+            put(sigStore.last!!.copyOfRange(4, 36))
+        }.array()
+        sigStore.last = negativeVersionBlob
+
+        assertThat(storage.read()).isNull()
+        assertThat(tamperEvents).containsExactly(TamperEvent.UnsupportedVersion(-1))
+    }
+
+    @Test
     fun `read fires InvalidSignature when blob is truncated below minimum size`() = runTest {
         val tamperEvents = mutableListOf<TamperEvent>()
         val (storage, _, sigStore) = newStorage(onTamperDetected = { tamperEvents += it })

--- a/billing/src/test/kotlin/com/kanetik/billing/entitlement/signed/SignedEntitlementStorageTest.kt
+++ b/billing/src/test/kotlin/com/kanetik/billing/entitlement/signed/SignedEntitlementStorageTest.kt
@@ -149,6 +149,25 @@ class SignedEntitlementStorageTest {
     }
 
     @Test
+    fun `write does not persist snapshot when keyProvider sign throws`() = runTest {
+        val delegate = InMemoryStorage()
+        val sigStore = InMemorySignatureStore()
+        val storage = SignedEntitlementStorage(
+            delegate, keyProvider = ThrowingKeyProvider, signatureStore = sigStore,
+        )
+
+        try {
+            storage.write(sampleSnapshot)
+            error("Expected IllegalStateException from sign()")
+        } catch (e: IllegalStateException) {
+            // expected
+        }
+
+        assertThat(delegate.lastWritten).isNull()
+        assertThat(sigStore.last).isNull()
+    }
+
+    @Test
     fun `write throws when keyProvider produces wrong-sized hmac`() = runTest {
         val storage = SignedEntitlementStorage(
             delegate = InMemoryStorage(),
@@ -279,4 +298,9 @@ private class FixedKeyHmacProvider(private val key: ByteArray) : HmacKeyProvider
         mac.init(SecretKeySpec(key, "HmacSHA256"))
         return mac.doFinal(data)
     }
+}
+
+private object ThrowingKeyProvider : HmacKeyProvider {
+    override suspend fun sign(data: ByteArray): ByteArray =
+        throw IllegalStateException("simulated key provider failure")
 }

--- a/billing/src/test/kotlin/com/kanetik/billing/entitlement/signed/SignedEntitlementStorageTest.kt
+++ b/billing/src/test/kotlin/com/kanetik/billing/entitlement/signed/SignedEntitlementStorageTest.kt
@@ -125,7 +125,7 @@ class SignedEntitlementStorageTest {
     }
 
     @Test
-    fun `read fires InvalidSignature when blob is truncated below minimum size`() = runTest {
+    fun `read fires InvalidSignature when blob is truncated below expected size`() = runTest {
         val tamperEvents = mutableListOf<TamperEvent>()
         val (storage, _, sigStore) = newStorage(onTamperDetected = { tamperEvents += it })
 
@@ -134,6 +134,37 @@ class SignedEntitlementStorageTest {
 
         assertThat(storage.read()).isNull()
         assertThat(tamperEvents).containsExactly(TamperEvent.InvalidSignature)
+    }
+
+    @Test
+    fun `read fires InvalidSignature when blob has trailing bytes beyond expected size`() = runTest {
+        val tamperEvents = mutableListOf<TamperEvent>()
+        val (storage, _, sigStore) = newStorage(onTamperDetected = { tamperEvents += it })
+
+        storage.write(sampleSnapshot)
+        sigStore.last = sigStore.last!! + ByteArray(4) { 0x42 }
+
+        assertThat(storage.read()).isNull()
+        assertThat(tamperEvents).containsExactly(TamperEvent.InvalidSignature)
+    }
+
+    @Test
+    fun `write throws when keyProvider produces wrong-sized hmac`() = runTest {
+        val storage = SignedEntitlementStorage(
+            delegate = InMemoryStorage(),
+            keyProvider = object : HmacKeyProvider {
+                override suspend fun sign(data: ByteArray): ByteArray = ByteArray(16) { 0x01 }
+            },
+            signatureStore = InMemorySignatureStore(),
+        )
+
+        try {
+            storage.write(sampleSnapshot)
+            error("Expected IllegalArgumentException")
+        } catch (e: IllegalArgumentException) {
+            assertThat(e.message).contains("16-byte")
+            assertThat(e.message).contains("32")
+        }
     }
 
     @Test
@@ -165,6 +196,24 @@ class SignedEntitlementStorageTest {
         )
         assertThat(storage.read()).isEqualTo(sampleSnapshot)
         assertThat(tamperEvents).isEmpty()
+    }
+
+    @Test
+    fun `migrateUnsignedSnapshot does not read delegate when signature already present`() = runTest {
+        val keyProvider = FixedKeyHmacProvider(KEY_BYTES)
+        val sigStore = InMemorySignatureStore().also { it.last = ByteArray(36) }
+        val delegate = object : EntitlementStorage {
+            var readCalls = 0
+            override suspend fun read(): EntitlementSnapshot? {
+                readCalls++; return null
+            }
+            override suspend fun write(snapshot: EntitlementSnapshot) = error("unexpected")
+        }
+
+        val migrated = SignedEntitlementStorage.migrateUnsignedSnapshot(delegate, keyProvider, sigStore)
+
+        assertThat(migrated).isFalse()
+        assertThat(delegate.readCalls).isEqualTo(0)
     }
 
     @Test

--- a/billing/src/test/kotlin/com/kanetik/billing/entitlement/signed/SignedEntitlementStorageTest.kt
+++ b/billing/src/test/kotlin/com/kanetik/billing/entitlement/signed/SignedEntitlementStorageTest.kt
@@ -242,7 +242,7 @@ class SignedEntitlementStorageTest {
         val firstBlob = sigStore.last!!.copyOf()
 
         val migrated = SignedEntitlementStorage.migrateUnsignedSnapshot(
-            delegate = storage, // re-using through the decorator is fine; delegate.read returns the same snapshot
+            delegate = storage,
             keyProvider = FixedKeyHmacProvider(KEY_BYTES),
             signatureStore = sigStore,
         )

--- a/billing/src/test/kotlin/com/kanetik/billing/entitlement/signed/SnapshotCanonicalBytesTest.kt
+++ b/billing/src/test/kotlin/com/kanetik/billing/entitlement/signed/SnapshotCanonicalBytesTest.kt
@@ -1,0 +1,82 @@
+package com.kanetik.billing.entitlement.signed
+
+import com.google.common.truth.Truth.assertThat
+import com.kanetik.billing.entitlement.EntitlementSnapshot
+import org.junit.Test
+import java.nio.ByteBuffer
+
+class SnapshotCanonicalBytesTest {
+
+    private val baseline = EntitlementSnapshot(
+        isEntitled = true,
+        confirmedAtMs = 1_700_000_000_000L,
+        purchaseToken = "tok-baseline",
+    )
+
+    @Test
+    fun `encode is deterministic for the same snapshot and version`() {
+        val a = SnapshotCanonicalBytes.encode(baseline, 1)
+        val b = SnapshotCanonicalBytes.encode(baseline, 1)
+        assertThat(a).isEqualTo(b)
+    }
+
+    @Test
+    fun `encode starts with the version int in big-endian`() {
+        val bytes = SnapshotCanonicalBytes.encode(baseline, 1)
+        val parsedVersion = ByteBuffer.wrap(bytes, 0, 4).int
+        assertThat(parsedVersion).isEqualTo(1)
+    }
+
+    @Test
+    fun `different isEntitled produces different bytes`() {
+        val truthy = SnapshotCanonicalBytes.encode(baseline, 1)
+        val falsy = SnapshotCanonicalBytes.encode(baseline.copy(isEntitled = false), 1)
+        assertThat(truthy).isNotEqualTo(falsy)
+    }
+
+    @Test
+    fun `different confirmedAtMs produces different bytes`() {
+        val original = SnapshotCanonicalBytes.encode(baseline, 1)
+        val shifted = SnapshotCanonicalBytes.encode(baseline.copy(confirmedAtMs = baseline.confirmedAtMs + 1), 1)
+        assertThat(original).isNotEqualTo(shifted)
+    }
+
+    @Test
+    fun `different purchaseToken produces different bytes`() {
+        val original = SnapshotCanonicalBytes.encode(baseline, 1)
+        val swapped = SnapshotCanonicalBytes.encode(baseline.copy(purchaseToken = "tok-other"), 1)
+        assertThat(original).isNotEqualTo(swapped)
+    }
+
+    @Test
+    fun `null and empty purchaseToken produce different bytes`() {
+        val nullToken = SnapshotCanonicalBytes.encode(baseline.copy(purchaseToken = null), 1)
+        val emptyToken = SnapshotCanonicalBytes.encode(baseline.copy(purchaseToken = ""), 1)
+        assertThat(nullToken).isNotEqualTo(emptyToken)
+    }
+
+    @Test
+    fun `null token sets token_len field to -1`() {
+        val bytes = SnapshotCanonicalBytes.encode(baseline.copy(purchaseToken = null), 1)
+        // version(4) + isEntitled(1) + confirmedAtMs(8) = 13, then token_len(4) at offset 13
+        val tokenLen = ByteBuffer.wrap(bytes, 13, 4).int
+        assertThat(tokenLen).isEqualTo(-1)
+    }
+
+    @Test
+    fun `empty token sets token_len field to 0`() {
+        val bytes = SnapshotCanonicalBytes.encode(baseline.copy(purchaseToken = ""), 1)
+        val tokenLen = ByteBuffer.wrap(bytes, 13, 4).int
+        assertThat(tokenLen).isEqualTo(0)
+    }
+
+    @Test
+    fun `unknown version throws IllegalArgumentException`() {
+        try {
+            SnapshotCanonicalBytes.encode(baseline, 999)
+            error("Expected IllegalArgumentException")
+        } catch (e: IllegalArgumentException) {
+            assertThat(e.message).contains("999")
+        }
+    }
+}


### PR DESCRIPTION
Closes the gap that kept freemium-with-real-value apps from adopting
EntitlementCache: the library now ships first-party tamper-resistance
helpers instead of telling consumers to roll their own crypto.

SignedEntitlementStorage decorates any EntitlementStorage, signing the
snapshot on write (HMAC-SHA256 over a versioned canonical encoding) and
verifying on read. Tampered snapshots are dropped; the cache reads them
as cold-start and OwnedPurchases.Live re-confirms truth.

Public API under com.kanetik.billing.entitlement.signed:
- SignedEntitlementStorage with TamperEvent callback that distinguishes
  MissingSignature (typically post-upgrade migration) from
  InvalidSignature (strong tamper indicator) and UnsupportedVersion.
- HmacKeyProvider with sign/verify shape (vs. the issue's key():
  ByteArray) so non-extractable Keystore keys are first-class.
- KeystoreBackedKeyProvider — Android Keystore HMAC-SHA256, the
  recommended default. Hardware-backed where available.
- ServerSeededKeyProvider — per-install seed fetched from a backend on
  first use, cached locally. Plaintext-cache caveat documented.
- SignatureStore / SeedCache interfaces with SharedPreferences-backed
  defaults; consumers can swap with their own backend.
- SignedEntitlementStorage.migrateUnsignedSnapshot static helper for
  adopters who want to avoid the one-time post-upgrade cold-start by
  trusting the existing snapshot once. Static + consumer-side state
  rather than a permanent decorator mode, so there's no perpetual
  "delete the sig file to bypass" attack window.

Wire format: 4-byte version || 32-byte HMAC-SHA256 over canonical bytes
that include the version, so an attacker can't downgrade signatures
across versions. Future EntitlementSnapshot field additions keep
existing v1 signatures verifying as long as the new field is nullable
or has a documented v1-default — no library-upgrade revocation event.

Updated EntitlementStorage KDoc and the README's tamper-protection
section to point at the new helpers. CHANGELOG entry under Unreleased.

Tests: 24 new (canonical bytes determinism + version prefix; all
read/write/migration paths through the decorator using a software
HmacKeyProvider; ServerSeededKeyProvider cache + verify behaviour).
Full :billing:test green at 129 tests, 0 failures. POM unchanged —
HMAC and Keystore are JDK / Android platform.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>