### PR TITLE
docs: lead with why-this-matters for new-to-PBL readers

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,35 +101,11 @@ class CheckoutActivity : ComponentActivity() {
 
 That's enough for a working one-time-IAP integration. Subscriptions work at the protocol level via raw `QueryPurchasesParams` + `BillingFlowParams`; subscription-specific helpers ship in v0.2.0 (see the [Roadmap](https://kanetik.github.io/billing-library/roadmap/)).
 
-> **⚠️ Two-tier `PurchaseEvent` — read before writing to your cache**
->
-> `observePurchaseUpdates()` emits `PurchaseEvent`, a marker interface with
-> two sealed roots:
->
-> - **`OwnedPurchases`** (`Live`, `Recovered`) — owned-state updates. The
->   user owns these purchases; acknowledge / consume / grant entitlement.
->   These are **incremental updates, not authoritative owned-state
->   snapshots** — `Live` carries the `PURCHASED`-or-`UNSPECIFIED_STATE`
->   subset of an `OK` callback, and `Recovered` carries only the
->   unacknowledged subset from the auto-sweep. Both channels are filtered
->   to non-empty before delivery (PBL occasionally fires the listener with
->   no purchases at all; the library drops those at the source). Merge
->   into your own entitlement state on `handlePurchase` Success rather
->   than replacing your cache from `event.purchases`. For managed
->   entitlement state with grace policy, use `EntitlementCache`.
-> - **`FlowOutcome`** (`Pending`, `Canceled`, `ItemAlreadyOwned`,
->   `ItemUnavailable`, `Failure`, `UnknownResponse`) — purchase-flow attempt outcomes.
->   These describe what *happened* on a single launch attempt. The
->   `purchases` list is typically empty (or, for `Pending`, purchases
->   that haven't completed yet) and **must not** be written to an
->   entitlement cache.
->
-> The marker interface doesn't expose `purchases` directly — you have to
-> narrow to `OwnedPurchases` or `FlowOutcome` first. That's what prevents
-> the original bug: writing `update.purchases` from a `Canceled` (or other
-> `FlowOutcome`) event into your entitlement cache. Note:
-> `OwnedPurchases.purchases` still isn't an authoritative owned-state
-> snapshot — see each variant's KDoc for the actual shape.
+A few things are worth a read once you're past the smoke test, especially if Play Billing is new to you:
+
+- [Purchase recovery](https://kanetik.github.io/billing-library/guides/purchase-recovery/) — what the two `PurchaseEvent` tiers actually are, why acknowledgement is a three-day cliff, and what the auto-sweep does about it. Probably the most important read in the docs.
+- [Error handling](https://kanetik.github.io/billing-library/guides/error-handling/) — the typed exception surface and which response codes the library retries automatically.
+- [EntitlementCache](https://kanetik.github.io/billing-library/guides/entitlement-cache/) — opt-in state machine for "is the user entitled right now," including signed/tamper-resistant storage.
 
 ## Where to go next
 

--- a/docs/guides/entitlement-cache.md
+++ b/docs/guides/entitlement-cache.md
@@ -1,6 +1,14 @@
 # EntitlementCache (opt-in)
 
-Most apps that consume `observePurchaseUpdates()` end up reinventing the same `(isEntitled, lastConfirmedTimestamp, source)` state machine: take the raw `PurchaseEvent` stream, decide which purchases grant a given entitlement, persist the verdict so premium UI can render before the first network round-trip, and add a grace window so a transient outage doesn't immediately yank features from a paid user. `EntitlementCache` (in `com.kanetik.billing.entitlement`) is that state machine, opt-in.
+Once your code can answer "did the user buy this" in the moment, three follow-up questions usually land within a few weeks of shipping:
+
+- How do I render premium UI on cold start, *before* the first PBL round-trip lands? (Otherwise paying users see the free-tier UI flicker every launch.)
+- What do I do when Play is unreachable for an hour or two — flip every paid user back to the free tier, or wait it out?
+- How do I keep my entitlement verdict consistent across process death, configuration changes, and app updates?
+
+PBL doesn't answer any of these. They're consumer concerns built on top of the protocol, which is why most apps end up reinventing the same `(isEntitled, lastConfirmedTimestamp, source)` state machine: take the raw `PurchaseEvent` stream, decide which purchases grant a given entitlement, persist the verdict so premium UI can render before the first network round-trip, and add a grace window so a transient outage doesn't immediately yank features from a paid user. `EntitlementCache` (in `com.kanetik.billing.entitlement`) is that state machine, opt-in.
+
+It listens to `observePurchaseUpdates()`, so it benefits from the auto-recovery sweep — see [Purchase recovery](purchase-recovery.md) for what `OwnedPurchases.Live` vs `OwnedPurchases.Recovered` actually mean and why you can't just write the callback's `purchases` list to your storage and call it done.
 
 ```kotlin
 import com.kanetik.billing.entitlement.EntitlementCache

--- a/docs/guides/error-handling.md
+++ b/docs/guides/error-handling.md
@@ -1,5 +1,12 @@
 # Error handling
 
+PBL hands you back errors as integer response codes on a `BillingResult` — `BILLING_RESPONSE_CODE_3`, `7`, `8`, etc. The codes have very different stakes: a `NETWORK_ERROR` is a "try again in a moment," `BILLING_UNAVAILABLE` means hide the in-app-purchase UI entirely (Play Store missing, account ineligible, region restriction), `ITEM_ALREADY_OWNED` is closer to a success-with-restore than an error, and `DEVELOPER_ERROR` means you wrote the API call wrong and retrying won't help. The naive integration treats them all the same and either hammers Play with retries or shows a generic "something went wrong" dialog for everything.
+
+The library does two things to make this tractable:
+
+1. Maps each response code to a typed `BillingException` subtype with a `RetryType` hint, and runs the retries that should happen automatically (network errors back off exponentially, transient disconnects retry quickly, ownership-mismatches re-query owned state and try once more). What reaches your `catch` is what didn't recover.
+2. Categorizes every exception into a `BillingErrorCategory` enum (seven buckets: `UserCanceled`, `Network`, `BillingUnavailable`, `ProductUnavailable`, `AlreadyOwned`, `DeveloperError`, `Other`) so your UI can localize per bucket without you having to memorize twelve response codes.
+
 Most `BillingActions` methods that fail throw a typed `BillingException` subtype — `queryPurchases`, `queryProductDetails`, `queryProductDetailsWithUnfetched`, `consumePurchase`, `acknowledgePurchase`, `launchFlow`, `showInAppMessages`, `isFeatureSupported`. The high-level `handlePurchase` helper is the exception: it returns a sealed `HandlePurchaseResult` with a `Failure(BillingException)` variant instead (see [Handling `handlePurchase` failures correctly](#handling-handlepurchase-failures-correctly) below). The library's retry loop already retries transient failures (`SIMPLE_RETRY`, `EXPONENTIAL_RETRY`, `REQUERY_PURCHASE_RETRY`) up to three times with appropriate backoff before throwing — what reaches your `catch` (or your `Failure` branch for `handlePurchase`) is whatever didn't recover. `launchFlow` runs once with no retry, because UI-initiated purchases shouldn't silently retry behind the user.
 
 For UI handling, branch on `userFacingCategory` (see [Showing errors to users](#showing-errors-to-users) below). For lower-level branching, use the sealed subtype directly:

--- a/docs/guides/purchase-recovery.md
+++ b/docs/guides/purchase-recovery.md
@@ -1,12 +1,42 @@
 # Purchase recovery
 
-Play auto-refunds purchases that aren't acknowledged within 3 days. App crashes, network failures, or process death mid-acknowledge can strand a paid purchase — without recovery, the user pays, gets refunded, and never sees the entitlement.
+If you've never shipped a Play Billing integration before, this is probably the most surprising thing about it: **a purchase isn't really yours until you acknowledge it, and Play auto-refunds anything you don't acknowledge within three days.** Not a soft warning, not a flag in the console — Play actually reverses the charge and the user loses entitlement. Crashes mid-acknowledge, network failures, the user force-quitting before your code finishes — any of those leaves a paid purchase stranded, and seventy-two hours later it's gone.
 
-The library handles this for you. On every fresh Play Billing connection (app start, post-disconnect reconnect, foregrounding after the connection released — the underlying connection uses `WhileSubscribed(60s)` so a quick background round-trip *doesn't* reconnect), it queries owned `INAPP` + `SUBS` purchases, filters for `PURCHASED && !isAcknowledged`, and emits any matches as `OwnedPurchases.Recovered`. Your existing `observePurchaseUpdates()` collector picks them up — no startup hook to wire, no scheduling code to write. (Exhaustive `when (event)` collectors do need a branch for `OwnedPurchases.Recovered` distinct from `OwnedPurchases.Live`; see the snippet below.)
+PBL doesn't help you with this. The acknowledge requirement is documented, but you're on the hook for noticing the failure and retrying. This guide is the most important read in the docs because it's the gotcha that costs real money — yours and the user's.
 
-This requires that *something* is driving the connection. The standard pattern uses `BillingConnectionLifecycleManager` (see [Lifecycle integration](lifecycle.md)), which collects `connectToBilling()` while a `LifecycleOwner` is started and triggers the recovery sweep automatically. Subscribing to `observePurchaseUpdates()` alone does **not** open the connection; pair it with the lifecycle manager (or your own `connectToBilling()` collector) so the sweep can fire. Internally the recovery channel uses `replay = 1` (see [Replay semantics](../reference/replay-semantics.md)), so a subscriber that attaches a moment after the sweep still receives the most recent recovered purchases.
+## What `PurchaseEvent` is, and why it has two roots
 
-The library handles `Recovered` dedupe for you. `BillingActions.handlePurchase` (and the lower-level `acknowledgePurchase` / `consumePurchase`) records the purchase token after the underlying acknowledge or consume call lands successfully against Play. The recovery channel still has `replay = 1` so the cache reflects current Play state, but `observePurchaseUpdates()` filters the cached snapshot against the acked-token set *at delivery time* (via a synchronous `map` that reads the current set per emission) — so even a late subscriber that attaches after you've already handled the purchase receives the cached sweep result re-filtered against the current acked set, not the stale pre-ack snapshot. Empty `Recovered` (intrinsic or filtered-to-empty) is dropped before delivery. There's nothing to dedupe in your collector:
+Before getting to the recovery sweep itself, a short conceptual detour. PBL gives you one callback — `PurchasesUpdatedListener` — that fires for two semantically different reasons that look identical at the API level:
+
+- **The user actually owns a purchase** — they just completed one via your active flow, or one was already in their account from a prior session that didn't finish processing.
+- **A launch attempt produced an outcome that isn't a purchase** — they canceled the dialog, the product wasn't available in their region, the network dropped, etc.
+
+Both arrive on the same listener with a `BillingResult` and a `List<Purchase>`. The naive integration treats them the same and writes the callback's purchase list to whatever entitlement state the app maintains. But a `USER_CANCELED` outcome carries an empty (or stale) purchase list, and writing that into a cache silently corrupts your entitlement state. People have shipped real apps that revoke premium when the user opens the purchase dialog and clicks Back.
+
+The library splits the callback into two sealed roots so the type system makes the mistake harder to make:
+
+- **`OwnedPurchases`** — the user owns these. Acknowledge / consume / grant entitlement. Two variants:
+    - `Live` — completed via the active purchase flow (or carried in an `OK` callback).
+    - `Recovered` — discovered by the auto-sweep on connect (this is what the rest of this guide is about).
+- **`FlowOutcome`** — describes what *happened* on a single launch attempt. Variants: `Pending` (deferred payment, e.g. cash or family approval), `Canceled`, `ItemAlreadyOwned`, `ItemUnavailable`, `Failure(BillingException)`, `UnknownResponse`. The `purchases` list on these is empty or transient. **Never write it to your entitlement cache.**
+
+There's also `PurchaseRevoked` (a third root, sibling to the two above) for server-driven revocation events — see [Server-driven revocation](server-driven-revocation.md) for that story.
+
+The `PurchaseEvent` marker interface deliberately doesn't expose `purchases` directly, so a `when` branch that wants to read purchases has to narrow to `OwnedPurchases` or `FlowOutcome` first. The wrong code now fails to compile rather than silently corrupting state.
+
+## How recovery works
+
+On every fresh Play Billing connection — app start, post-disconnect reconnect, foregrounding after the connection released — the library queries owned `INAPP` + `SUBS` purchases from Play, filters to `PURCHASED && !isAcknowledged`, and emits any matches as `OwnedPurchases.Recovered`. Your existing `observePurchaseUpdates()` collector picks them up. There's no startup hook to wire and no scheduling code to write.
+
+(About "fresh connection": the library's `connectToBilling()` is shared via `WhileSubscribed(60s)`, so a quick background round-trip — collapsed activity, brief task switch — *doesn't* tear down and recreate the connection, and therefore *doesn't* re-run the sweep on resume. The sweep fires when the connection actually transitions from disconnected to OK. See [Replay semantics](../reference/replay-semantics.md) for the timing details.)
+
+This requires that *something* is driving the connection. The standard pattern uses `BillingConnectionLifecycleManager` (see [Lifecycle integration](lifecycle.md)), which collects `connectToBilling()` while a `LifecycleOwner` is started and triggers the sweep automatically. Subscribing to `observePurchaseUpdates()` alone does **not** open the connection; pair it with the lifecycle manager (or your own `connectToBilling()` collector) so the sweep can fire.
+
+The recovery channel uses `replay = 1` internally, so a subscriber that attaches a moment after the sweep still receives the most recent recovered purchases. That's important: in many apps the collector is in a ViewModel that races the connection coming up.
+
+## Handling `Recovered` events
+
+Same code path as `Live`. Hand each purchase to `handlePurchase` — that's the helper that performs the acknowledge or consume against Play and short-circuits if the purchase is already acknowledged.
 
 ```kotlin
 is OwnedPurchases.Recovered -> event.purchases.forEach { purchase ->
@@ -35,7 +65,13 @@ is OwnedPurchases.Recovered -> event.purchases.forEach { purchase ->
 }
 ```
 
-You should still treat the `Recovered` branch idempotently if you fire other one-shot UX off it (badge animations, analytics events, etc.) — but the `Set<String>` dedupe consumers used to need against `replay = 1` re-emission is no longer required. Tracking lives for the singleton repository's lifetime (typically the process), bounded by purchase activity; a fresh sweep on reconnect re-queries Play and surfaces only genuinely-unacked tokens. (Live events on the `OwnedPurchases.Live` branch don't need this — see [Replay semantics](../reference/replay-semantics.md).)
+You don't need a consumer-side dedupe `Set<String>`. Earlier versions of the library required one because `replay = 1` would re-deliver the cached snapshot to a re-attached collector even after the consumer had already acknowledged the purchase. The library now tracks acknowledged tokens internally (in `BillingClientStorage.acknowledgedTokens`) and filters the cached snapshot against that set at delivery time — so re-attached subscribers don't see already-handled recovered purchases.
+
+You should still treat the `Recovered` branch idempotently if you fire other one-shot UX off it (badge animations, analytics events, etc.) — the library's dedupe is about not re-handling the *purchase*, not about coalescing your side-effects.
+
+## Live vs. Recovered: when the UX should differ
+
+`Live` and `Recovered` are separate variants so you can branch your UX. Don't show "thanks for your purchase!" on a sweep that ran when the user opened the app. The handle/grant code is identical for one-time products; only the surrounding UX differs.
 
 ```kotlin
 billing.observePurchaseUpdates().collect { event ->
@@ -45,10 +81,8 @@ billing.observePurchaseUpdates().collect { event ->
             fireConfetti() // user-initiated; celebrate
         }
         is OwnedPurchases.Recovered -> {
-            // Same handle() call as Live — but no confetti. Background recovery,
-            // not a fresh purchase. The library tracks acknowledged tokens internally
-            // and suppresses replay of `Recovered` for already-handled purchases —
-            // you don't need a consumer-side `Set<String>` dedupe.
+            // Same handle() call as Live — but no confetti. Background
+            // recovery, not a fresh purchase.
             event.purchases.forEach { handle(it) }
         }
         is FlowOutcome -> { /* sub-when on Pending / Canceled / etc. */ }
@@ -56,9 +90,11 @@ billing.observePurchaseUpdates().collect { event ->
 }
 ```
 
-`Live` and `Recovered` are separate variants so you can branch your UX — don't show "thanks for your purchase!" on a sweep that ran when the user opened the app. The handle/grant code is identical for one-time products.
+## Subscription replacements need extra care (until v0.2.0)
 
-**Subscription replacements need special handling (until v0.2.0).** Subscription upgrade/downgrade/crossgrade purchases carry a non-null `linkedPurchaseToken` pointing at the prior subscription. Treating them as fresh grants double-grants entitlement on plan changes. PBL's `Purchase` API doesn't expose a getter for `linkedPurchaseToken` (`AccountIdentifiers` only carries `obfuscatedAccountId` / `obfuscatedProfileId`); the field is only present in `purchase.originalJson`. Until v0.2.0 ships the typed `SubscriptionReplacement` variant (see the [Roadmap](../roadmap.md)), consumers using subscriptions need to parse it themselves:
+Subscription upgrade/downgrade/crossgrade purchases carry a non-null `linkedPurchaseToken` pointing at the prior subscription. If you treat one as a fresh grant rather than a replacement, you've double-granted entitlement on the plan change — the new purchase shows up in `OwnedPurchases.Live` (or `Recovered` if recovered after a crash) and looks identical to a brand-new buy.
+
+PBL's `Purchase` API doesn't expose a getter for `linkedPurchaseToken` (`AccountIdentifiers` only carries `obfuscatedAccountId` / `obfuscatedProfileId`); the field is only present in `purchase.originalJson`. Until v0.2.0 ships the typed `OwnedPurchases.SubscriptionReplacement` variant (see the [Roadmap](../roadmap.md)), consumers using subscriptions need to parse it themselves:
 
 ```kotlin
 fun Purchase.linkedPurchaseToken(): String? = try {
@@ -68,9 +104,11 @@ fun Purchase.linkedPurchaseToken(): String? = try {
 } catch (e: org.json.JSONException) { null }
 ```
 
-Treat a non-null result as a plan change (invalidate the old token, grant against the new one) rather than a fresh purchase. IAP-only apps are unaffected — one-time products never carry a `linkedPurchaseToken`.
+A non-null result is a plan change: invalidate the old token's grant and grant against the new one. IAP-only apps are unaffected — one-time products never carry a `linkedPurchaseToken`.
 
-To opt out (e.g. you run a server-side reconciliation queue):
+## Opting out
+
+If you run a server-side reconciliation queue that you'd rather have own this concern:
 
 ```kotlin
 val billing = BillingRepositoryCreator.create(
@@ -78,3 +116,5 @@ val billing = BillingRepositoryCreator.create(
     recoverPurchasesOnConnect = false
 )
 ```
+
+The auto-sweep is opt-out, not opt-in, because the failure mode of skipping recovery is silent and asymmetric (paid users lose entitlement) and most apps shouldn't run without it.

--- a/docs/guides/signature-verification.md
+++ b/docs/guides/signature-verification.md
@@ -1,6 +1,10 @@
 # Signature verification
 
-`PurchaseVerifier` (in `com.kanetik.billing.security`) does RSA signature verification of `Purchase.originalJson` against your app's public key. The recommended integration:
+Play's signature is the only on-device proof that a `Purchase` actually came from Google rather than from a malicious app forging the response or from a man-in-the-middle tampering with the intent. PBL hands you `Purchase.signature` and `Purchase.originalJson`, but it doesn't validate them — that's on you. Skipping verification leaves your entitlement checks trusting whatever the device hands the listener, which on a rooted phone is whatever the user (or a tool they're running) wants it to be.
+
+`PurchaseVerifier` (in `com.kanetik.billing.security`) does RSA signature verification of `Purchase.originalJson` against your app's public key (Play Console gives you the key when you create the app — Monetization setup → Licensing). It's a small piece of code with a high payoff: a verified `Purchase` is one Play vouches for, and an unverified one shouldn't grant entitlement no matter how convincing it looks.
+
+The recommended integration:
 
 ```kotlin
 val verifier = PurchaseVerifier(base64PublicKey = BuildConfig.PLAY_BILLING_PUBLIC_KEY)

--- a/docs/guides/subscriptions.md
+++ b/docs/guides/subscriptions.md
@@ -1,6 +1,10 @@
 # Subscriptions (v0.1.x)
 
-The v0.1.x series supports subscriptions at the *protocol* level — `queryPurchases`, `queryProductDetails`, `launchFlow` all accept `BillingClient.ProductType.SUBS`. What's missing in v0.1.x:
+Subscriptions are a deeper rabbit hole than one-time purchases. PBL adds offer-token selection (a single product can have multiple base plans, each with multiple offers — free trials, intro pricing, regional discounts), multi-line-item replacements (upgrades / downgrades / add-ons in a single flow), deferred billing for prepaid plans, and a `linkedPurchaseToken` field that — if you miss it — double-grants entitlement on every plan change because the new purchase looks identical to a fresh buy. Most apps that ship subs and skip these end up either over-granting (free upgrades for everyone who taps the wrong button) or stranding users on stale plans.
+
+The v0.1.x series supports subscriptions at the *protocol* level — `queryPurchases`, `queryProductDetails`, `launchFlow` all accept `BillingClient.ProductType.SUBS`. What that means in practice: you can buy / observe / acknowledge subscriptions today, but the offer-selection and replacement-mode helpers that make the dev ergonomics tolerable are still on you. Typed helpers land in v0.2.0; this guide documents the manual path until then.
+
+What's missing in v0.1.x:
 
 - Subscription offer-token selection helpers.
 - Multi-line-item replacement helpers (`SubscriptionProductReplacementParams`).

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,19 @@
 
 A coroutine-first wrapper around [Google Play Billing Library 8.x](https://developer.android.com/google/play/billing). The [README](https://github.com/kanetik/billing-library#readme) covers what the library is and the bare-minimum integration; this site is the deeper reference.
 
+## New to Play Billing?
+
+If you haven't shipped a Play Billing integration before, the docs work best in this order:
+
+1. [Installation](installation.md) and [Quick start](quick-start.md) — get something running.
+2. [Purchase recovery](guides/purchase-recovery.md) — what `PurchaseEvent` is, why it has two tiers, and the three-day acknowledge cliff that catches almost everyone the first time. The most important read.
+3. [Error handling](guides/error-handling.md) — typed exceptions, the seven UI categories, and the retry loop the library runs for you.
+4. [EntitlementCache](guides/entitlement-cache.md) — opt-in but most apps end up wanting it.
+5. [Signature verification](guides/signature-verification.md) — proving a `Purchase` actually came from Google.
+6. [Server-driven revocation](guides/server-driven-revocation.md) — how refunds and chargebacks reach the app.
+
+The rest of the guides below are scenario-specific reference; pick them up when the situation comes up.
+
 ## What you'll find here
 
 ### Getting set up

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -85,18 +85,12 @@ class CheckoutActivity : ComponentActivity() {
 
 That's enough for a working one-time-IAP integration.
 
-!!! warning "Two-tier `PurchaseEvent` — read before writing to your cache"
+## What's worth reading next
 
-    `observePurchaseUpdates()` emits `PurchaseEvent`, a marker interface with two sealed roots:
+A few topics are worth picking up before you ship — especially if Play Billing is new to you. The order below isn't strict, but it's the order that builds context if you read sequentially:
 
-    - **`OwnedPurchases`** (`Live`, `Recovered`) — owned-state updates. The user owns these purchases; acknowledge / consume / grant entitlement. These are **incremental updates, not authoritative owned-state snapshots** — `Live` carries the `PURCHASED`-or-`UNSPECIFIED_STATE` subset of an `OK` callback, and `Recovered` carries only the unacknowledged subset from the auto-sweep. Both channels are filtered to non-empty before delivery (PBL occasionally fires the listener with no purchases at all; the library drops those at the source). Merge into your own entitlement state on `handlePurchase` Success rather than replacing your cache from `event.purchases`. For managed entitlement state with grace policy, use [`EntitlementCache`](guides/entitlement-cache.md).
-    - **`FlowOutcome`** (`Pending`, `Canceled`, `ItemAlreadyOwned`, `ItemUnavailable`, `Failure`, `UnknownResponse`) — purchase-flow attempt outcomes. These describe what *happened* on a single launch attempt. The `purchases` list is typically empty (or, for `Pending`, purchases that haven't completed yet) and **must not** be written to an entitlement cache.
-
-    The marker interface doesn't expose `purchases` directly — you have to narrow to `OwnedPurchases` or `FlowOutcome` first. That's what prevents the original bug: writing `update.purchases` from a `Canceled` (or other `FlowOutcome`) event into your entitlement cache. Note: `OwnedPurchases.purchases` still isn't an authoritative owned-state snapshot — see each variant's KDoc for the actual shape.
-
-## Next steps
-
-- [Purchase recovery](guides/purchase-recovery.md) — what happens when an acknowledge lands the next time the connection comes up
-- [Error handling](guides/error-handling.md) — `BillingException` subtypes, `userFacingCategory`, the `HandlePurchaseResult` branches
-- [EntitlementCache](guides/entitlement-cache.md) — opt-in state machine for "is the user entitled right now?"
-- [Testing](testing.md) — the three-levels approach (static SKUs / license tester / Play Billing Lab)
+- [Purchase recovery](guides/purchase-recovery.md) — what `PurchaseEvent`'s two tiers actually are (and why splitting them matters), why acknowledgement is a three-day cliff that costs real money if you miss it, and what the library's auto-sweep does for you. Probably the most important read in the docs.
+- [Error handling](guides/error-handling.md) — typed exceptions, the seven `BillingErrorCategory` UI buckets, and the retry strategy the library runs before throwing.
+- [EntitlementCache](guides/entitlement-cache.md) — opt-in state machine that answers "is the user entitled right now," with a grace window for transient Play outages and signed/tamper-resistant storage if your threat model needs it.
+- [Signature verification](guides/signature-verification.md) — proving an incoming `Purchase` actually came from Google.
+- [Testing](testing.md) — the three-levels approach (static SKUs / license tester / Play Billing Lab).


### PR DESCRIPTION
## Summary

Reshape the docs so they're useful to a smart developer who's *new to Play Billing*, not just to someone who already knows where the gotchas are. Three changes:

- **Move the "Two-tier `PurchaseEvent`" warning out of the README/Quick Start.** It was landing before any context for what "your cache" meant or why caching was even a topic, which made it more alarming than informative for a first-time reader. The conceptual content now lives in the Purchase recovery guide where the recovery sweep gives it a problem to solve.
- **Restructure `docs/guides/purchase-recovery.md` to lead with the why.** The three-day acknowledgement cliff stated plainly up top, then the `OwnedPurchases` / `FlowOutcome` split as proper exposition (the naive failure mode → why splitting matters), then the existing how-to. This is now the load-bearing concept doc for the library.
- **Add a "why this matters" intro to four other guides** (error-handling, entitlement-cache, signature-verification, subscriptions) framing the PBL gotcha or design pressure each one addresses. Voice is warmer than the previous jumps-straight-to-API style, but not handholding — target audience is a smart dev unfamiliar with PBL specifically, not a beginner.

`docs/index.md` gets a "New to Play Billing?" reading-order block at the top so a sequential reader has a clear path through the guides ordered by conceptual dependency.

## Why

The previous docs assumed a reader who already knew PBL is dangerous in specific ways (the 3-day acknowledge window, signature forgery on rooted devices, the linkedPurchaseToken double-grant on plan changes, etc.). One of the core goals of this library is to enable devs who *aren't* PBL experts to ship secure, stable, high-success-rate billing integrations — and the docs were inconsistent with that goal.

## Reading order across the three commits

The commits are receivers-first so no commit leaves the docs in a half-broken state:

1. `64c5204` — Restructure `purchase-recovery.md` to host the new conceptual material.
2. `12e28ad` — Add why-intros to the other guides.
3. `66b0e9a` — Drop the warning callout from `README.md` and `docs/quick-start.md`, add the suggestion-toned next-steps paragraph, add the reading-order block to `docs/index.md`.

## Test plan

- [ ] Read `docs/guides/purchase-recovery.md` end-to-end as if encountering it for the first time. The opening paragraph should make the recovery sweep feel inevitable, not arbitrary.
- [ ] Read `README.md`'s post-Quick-Start paragraph. Should feel like a suggestion ("worth a read once you're past the smoke test"), not an instruction.
- [ ] Visit the Pages site after merge, click into each guide. Each one's opening paragraphs should tell a new-to-PBL reader what they're about to learn and why it matters.
- [ ] Confirm `mkdocs build --strict` passes (the docs.yml workflow run on this PR will verify).

🤖 Generated with [Claude Code](https://claude.com/claude-code)