### PR TITLE
build(deps): bump play-billing-ktx 8.3.0 → 9.0.0 (beta — risky changes flagged)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   completes once `BillingClient.launchBillingFlow` has returned (i.e., the
   request was submitted to Play) — PBL exposes no "UI rendered" signal, so
   completion is not a visibility guarantee. (#17)
+- **(beta)** Bumped Play Billing Library `8.3.0` → `9.0.0`
+  ([release notes](https://developer.android.com/google/play/billing/release-notes)).
+  PBL 9 changes the response code for a blocked Play Store app (e.g.,
+  OEM-customized kids mode) from `ERROR` to `BILLING_UNAVAILABLE`. Consumers
+  who match on `BillingException.FatalErrorException` or
+  `BillingErrorCategory.Other` specifically for the Play-Store-blocked scenario
+  will now receive `BillingUnavailableException` /
+  `BillingErrorCategory.BillingUnavailable` instead, with retry-hint `NONE`
+  (was `EXPONENTIAL_RETRY`). No wrapper code changes required — the library
+  already handled both codes correctly.
+
+### Risky items flagged for follow-up
+
+- **PBL 9.0.0 — `ERROR` → `BILLING_UNAVAILABLE` for blocked Play Store
+  ([release notes](https://developer.android.com/google/play/billing/release-notes)).**
+  When the Play Store app is blocked by the system, PBL now returns
+  `BILLING_UNAVAILABLE` instead of `ERROR`. Observable wrapper-side effects:
+  `BillingUnavailableException` (retry: `NONE`, category: `BillingUnavailable`)
+  is now thrown instead of `FatalErrorException` (retry: `EXPONENTIAL_RETRY`,
+  category: `Other`). Consumers who relied on exponential-retry behavior for
+  this condition, or who pattern-matched on `FatalErrorException` /
+  `BillingErrorCategory.Other` for it, need to update their handling.
 
 ## [0.1.1] - 2026-05-03
 

--- a/billing/src/test/kotlin/com/kanetik/billing/HandlePurchaseTest.kt
+++ b/billing/src/test/kotlin/com/kanetik/billing/HandlePurchaseTest.kt
@@ -58,7 +58,7 @@ class HandlePurchaseTest {
     }
 
     @Test
-    fun `handlePurchase with consume=true does NOT short-circuit on isAcknowledged — still consumes`() = runTest {
+    fun `handlePurchase with consume=true does NOT short-circuit on isAcknowledged - still consumes`() = runTest {
         // The consume=true path must run regardless of isAcknowledged state:
         // consumables aren't acked, they're consumed, and Play doesn't
         // expose isConsumed on Purchase for a parallel check. (If isAcknowledged

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@
 # pin in sync if AGP is bumped.
 androidGradlePlugin = "9.2.1"
 kotlin = "2.3.21"
-playBillingKtx = "8.3.0"
+playBillingKtx = "9.0.0"
 kotlinxCoroutines = "1.11.0"
 lifecycle = "2.10.0"
 coreKtx = "1.18.0"


### PR DESCRIPTION
Automated bump by daily PBL update Routine. Routed to `next` because the release contains changes that warrant maintainer review before merging to `main`.

## Version delta
Pinned: 8.3.0
Latest stable: 9.0.0
Release notes: https://developer.android.com/google/play/billing/release-notes

## Categorization
Risky — patch beta on `next`.

### Risky items
- **PBL 9.0.0 — `ERROR` → `BILLING_UNAVAILABLE` for blocked Play Store.** When the Play Store app is blocked by the system (e.g., OEM-customized kids mode), PBL now returns `BILLING_UNAVAILABLE` instead of `ERROR`. Observable wrapper-side effects: `BillingUnavailableException` (retry: `NONE`, category: `BillingUnavailable`) is now thrown instead of `FatalErrorException` (retry: `EXPONENTIAL_RETRY`, category: `Other`). No wrapper code changes are required — the library already handled both codes correctly. Consumers who pattern-matched on `BillingException.FatalErrorException` or `BillingErrorCategory.Other` specifically for the Play-Store-blocked scenario need to update their handling. The reclassification is arguably a correction: `BILLING_UNAVAILABLE` is semantically more accurate for a blocked storefront than the generic `ERROR`.

### Public API changes
None — wrapper public API is unchanged.

### Safe items (along for the ride)
- `DeveloperProvidedBillingDetails.getLinkUri()` marked `@Nullable` in PBL 9.0.0 (the class was introduced in 8.3.0). The wrapper does not expose this class; no consumer-visible impact.
- New in-app messaging capability for opt-in price increases (message shown from the first day users can accept the increase, max once every 7 days). No new wrapper code needed — the existing `else -> NoActionNeeded` branch in `mapInAppMessageResult` handles any new `InAppMessageResponseCode` variants gracefully.
- PBL `targetSdkVersion` updated to 35 (internal to PBL; no consumer-side action required).
- PBL 9.0.0 requires `androidx.core` ≥ 1.9. The wrapper already pins `core-ktx = "1.18.0"` — already satisfied.

## Suggested wrapper version
**0.1.2-beta1**
Rationale: Wrapper public API unchanged, no minSdk change → patch per the semver table in the playbook. Routed to `next` (rather than a straight patch to `main`) because the PBL `ERROR` → `BILLING_UNAVAILABLE` behavior change is consumer-visible and warrants explicit maintainer review before shipping as GA.

## Branch creation note
This PR is the first time the `next` branch was used. Created from `main` at commit `cf9ae3c` on 2026-05-22.

## Test fix note
A pre-existing test method name contained an em dash (`—`, U+2014), which caused an `InvalidPathException` when the Kotlin compiler tried to create the `.class` file on a JVM with ASCII-only native file encoding (`sun.jnu.encoding = ANSI_X3.4-1968`). The em dash was replaced with a hyphen-minus in the method name. Test logic is entirely unchanged. This failure is unrelated to the PBL bump — the same encoding mismatch would manifest on any clean build in this environment regardless of the PBL version.

## Verification
- `:billing:test` — 137 tests passed
- `:sample:assembleDebug` — succeeded
- `:billing:lint` — clean

## What the maintainer should do
1. Review the risky items list and confirm whether the `ERROR` → `BILLING_UNAVAILABLE` reclassification is acceptable for your consumer base.
2. Confirm there are no public API changes to audit (there are none).
3. Merge to `next` when satisfied.
4. Tag `v0.1.2-beta1` from `next` to publish the beta.
5. After dog-fooding, fast-forward `main` to `next` and tag `v0.1.2` GA.

---
_Generated by [Claude Code](https://claude.ai/code/session_013jSr9wPh2ChbY3A9vue1HR)_