### PR TITLE
docs: drop next-branch model from automated PBL update playbook

### DIFF
--- a/docs/_internal/automated-update-playbook.md
+++ b/docs/_internal/automated-update-playbook.md
@@ -128,7 +128,7 @@ A match is any open PR whose head branch starts with `bump/pbl-`. Identify the t
 
 1. Decide whether to update in place or re-template:
    - Old PR was safe and the delta from `<OLD_TARGET>` → `<NEW_TARGET>` adds only safe items → **update in place** (no template change).
-   - Old PR was safe but the additional versions in scope add risky items → categorization flips. **Update in place**: rename the PR title to the risky template (section 6), rewrite the body to the risky template, re-stamp the CHANGELOG entry as a risky bump (under `[Unreleased]`, `**(beta)**` qualifier). Branch name (`bump/pbl-<OLD>`) can stay as-is — it's a minor cosmetic mismatch with the conventional `-beta` suffix but doesn't break anything; alternatively the agent may open a fresh `bump/pbl-<NEW>-beta` branch and close the old PR with `Superseded by #<NEW_PR>` (only if a `Superseded by #` comment isn't already there — keep idempotent across daily runs). Prefer update-in-place unless the branch-name cosmetic bothers the maintainer; both are acceptable. **This update-in-place + re-template is the only path a single bump PR transitions through during its lifetime** — see §10.
+   - Old PR was safe but the additional versions in scope add risky items → categorization flips. **Update in place**: rename the PR title to the risky template (section 6), rewrite the body to the risky template, re-stamp the CHANGELOG entry as a risky bump (under `[Unreleased]`, `**(beta)**` qualifier). Branch name (`bump/pbl-<OLD>`) can stay as-is — it's a minor cosmetic mismatch with the conventional `-beta` suffix but doesn't break anything; alternatively the agent may open a fresh `bump/pbl-<NEW>-beta` branch and supersede the old PR with a `Superseded by #<NEW_PR>` comment for the maintainer to close (only if a `Superseded by #` comment isn't already there — keep idempotent across daily runs). Prefer update-in-place unless the branch-name cosmetic bothers the maintainer; both are acceptable. **This update-in-place + re-template is the only path a single bump PR transitions through during its lifetime** — see §10.
    - Old PR was risky → update in place (template already matches).
 2. Updating in place:
    - Pull the branch locally and rebase `main` into it so it's current.
@@ -369,7 +369,7 @@ Same as a safe bump: `./gradlew :billing:test :sample:assembleDebug :billing:lin
   Migration guide: <URL if any major boundary in scope, else "N/A — no major boundary crossed">
 
   ## Categorization
-  Risky — minor or major beta, tag as `<NEXT_VERSION>-beta1` after merge.
+  Risky — minor or major beta, tag as `v<NEXT_VERSION>-beta1` after merge.
 
   ### Risky items
   - <each risky change with: what it is, why it's risky, what the wrapper now does>

--- a/docs/_internal/automated-update-playbook.md
+++ b/docs/_internal/automated-update-playbook.md
@@ -4,7 +4,7 @@ This playbook is invoked by a **Claude.ai Routine** on a daily schedule. The Rou
 
 **Audience:** the agent firing on the Routine, plus the human maintainer who reviews the PRs (and occasionally the issues) it opens.
 
-**Purpose:** detect new stable PBL releases, categorize them as safe or risky, fix anything the bump breaks in the wrapper, and open a high-quality PR against the correct branch for human review. The agent never auto-merges, never tags, never pushes to `main` directly.
+**Purpose:** detect new stable PBL releases, categorize them as safe or risky, fix anything the bump breaks in the wrapper, and open a high-quality PR against `main` for human review. The agent never auto-merges, never tags, never pushes to `main` directly.
 
 ---
 
@@ -14,9 +14,9 @@ This playbook is invoked by a **Claude.ai Routine** on a daily schedule. The Rou
 
 - Detects new PBL stable versions
 - Reads both the release notes and the "Migrate to Billing Library X" guide — guide is required reading when a major boundary is in scope, advisory (but worth skimming) otherwise
-- Categorizes each release as **safe** (bug fix / internal-only) or **risky** (API change / behavior change / minSdk bump)
-- Fixes any code or test failures the bump introduces, on the appropriate branch
-- Opens or updates a PR against `main` (safe) or `next` (risky), with categorization rationale and a clear summary of what changed (and refreshes an existing open bump PR in place rather than opening a duplicate — see section 3)
+- Categorizes each release as **safe** (bug fix / internal-only) or **risky** (API change / behavior change / minSdk bump). Categorization determines the PR template and the tag flavor the maintainer cuts after merge — safe → `vX.Y.Z`, risky → `vX.Y.Z-beta1` first, then `vX.Y.Z` GA after dog-fooding. Both flavors target `main`.
+- Fixes any code or test failures the bump introduces before opening the PR
+- Opens or updates a PR against `main`, with categorization rationale and a clear summary of what changed (and refreshes an existing open bump PR in place rather than opening a duplicate — see section 3)
 - Opens a separate `[feat proposal]` GitHub issue (labeled `question`) for each net-new PBL feature, @-mentioning the maintainer
 - Notifies the maintainer via IFTTT (SMS to Android) when a new PR is opened, or when an existing PR's target version is bumped (a stale-target refresh per section 3 — audit fixes and rebase-only refreshes do **not** re-ping), plus one ping per feature-proposal issue and one per intervention issue
 
@@ -27,7 +27,7 @@ This playbook is invoked by a **Claude.ai Routine** on a daily schedule. The Rou
 - Tag any release
 - Bump any dependency other than `playBillingKtx`
 - **Open a PR (draft or otherwise) with a failing build or failing tests.** This is absolute. If the bump breaks something, the agent fixes it before opening the PR. If it can't fix in three attempts, it opens an *issue* instead, with full diagnostic detail.
-- **Auto-include net-new PBL features in the bump PR.** New PBL APIs the wrapper does not already expose go to a feature-proposal issue (section 4). The only exception is a trivial overload of a method the wrapper already wraps, where the new signature follows mechanically from the existing wrapping — and that exception is **Path B only**, because any new function in `com.kanetik.billing.*` is a public-API change.
+- **Auto-include net-new PBL features in the bump PR.** New PBL APIs the wrapper does not already expose go to a feature-proposal issue (section 4). The only exception is a trivial overload of a method the wrapper already wraps, where the new signature follows mechanically from the existing wrapping — and that exception applies on **risky bumps only**, because any new function in `com.kanetik.billing.*` is a public-API change.
 
 ### Working-assumption when something fails
 
@@ -37,12 +37,12 @@ It's not impossible for the test to be at fault — but the order of investigati
 
 ### Public API changes
 
-- **On `main` (Path A):** never. If the bump turns out to require any change to types or signatures in `com.kanetik.billing.*`, the categorization flips from safe to risky and the work moves to `next`.
-- **On `next` (Path B):** allowed and expected. Risky bumps may require new types, removed types, or signature changes in `com.kanetik.billing.*` to absorb upstream PBL changes cleanly. The PR body must enumerate every public-API change with a "**BREAKING:**" prefix so reviewers can audit them in one place.
+- **On a safe bump:** never. If the bump turns out to require any change to types or signatures in `com.kanetik.billing.*`, the categorization flips from safe to risky (section 7 covers the mechanics — no branch switch is required; the PR is re-templated in place or reopened on a `-beta` branch, agent's choice).
+- **On a risky bump:** allowed and expected. Risky bumps may require new types, removed types, or signature changes in `com.kanetik.billing.*` to absorb upstream PBL changes cleanly. The PR body must enumerate every public-API change with a "**BREAKING:**" prefix so reviewers can audit them in one place.
 
 ### Draft PRs are for *ambiguity*, not for failures
 
-A draft PR is the right tool when the agent's categorization confidence is below ~80%, when a migration choice has multiple reasonable paths, or when the agent is uncertain about a public-API decision on `next`. In those cases the agent opens a draft and posts its specific questions in the PR description (and follows up in PR comments if more come up while writing).
+A draft PR is the right tool when the agent's categorization confidence is below ~80%, when a migration choice has multiple reasonable paths, or when the agent is uncertain about a public-API decision on a risky bump. In those cases the agent opens a draft and posts its specific questions in the PR description (and follows up in PR comments if more come up while writing).
 
 A draft PR is **not** acceptable as a way to ship work with failing tests or a broken build. If something's failing, the agent fixes it (section 7) or opens an issue.
 
@@ -106,16 +106,16 @@ A match is any open PR whose head branch starts with `bump/pbl-`. Identify the t
 
 1. Read the PR end-to-end — title, body, diff, file changes, comments, CI status.
 2. Audit it against this playbook:
-   - Categorization correct (safe vs risky, Path A vs Path B, right base branch)?
+   - Categorization correct (safe vs risky, right CHANGELOG version stamp)?
    - Every change in release notes enumerated in the PR body?
-   - For Path B, every public-API change labeled `**BREAKING:**`?
+   - For risky bumps, every public-API change labeled `**BREAKING:**`?
    - **Migration guide URL** present in the PR body (if a major boundary is crossed)?
    - **Feature-proposal issues** linked under "Feature proposals deferred to follow-up issues" (if any net-new PBL features exist in the version range)?
    - CHANGELOG entry present and in the templated format from section 5 or 6?
    - Latest commit passes `:billing:test :sample:assembleDebug :billing:lint`?
    - Any maintainer review comments unaddressed?
 3. If any audit item is missing or wrong, work on the **existing branch** — never open a duplicate PR. Do the following in this exact order:
-   - Pull the branch locally and rebase its base (`main` or `next`) into it so the fixes and the verification run against the current state of the base branch.
+   - Pull the branch locally and rebase `main` into it so the fixes and the verification run against the current state of `main`.
    - Apply the audit fixes. If they changed the categorization, release-notes enumeration, or linked feature-proposal issues, also update the PR title and body to match.
    - Re-run verification (`:billing:test :sample:assembleDebug :billing:lint`). Only continue if it passes; if it fails, go to section 7.
    - Push with `git push --force-with-lease` (the rebase rewrote history, so a plain push will be rejected as non-fast-forward; `--force-with-lease` is preferred over `--force` because it refuses to clobber commits the agent hasn't seen).
@@ -126,21 +126,21 @@ A match is any open PR whose head branch starts with `bump/pbl-`. Identify the t
 
 **An open PR targets a stale version** (e.g., PR is for 8.5.0 but latest stable is now 8.5.1, or pinned was 8.3.0 and the old PR jumped to 8.4.0 while latest is now 8.5.0):
 
-1. Decide whether to update in place or re-route:
-   - Old PR was Path A and the delta from `<OLD_TARGET>` → `<NEW_TARGET>` adds only safe items → **update in place**.
-   - Old PR was Path A but the additional versions in scope add risky items → categorization flips. Open a fresh PR on `next` per section 6. On the old Path A PR, post a comment (only if a `Superseded by #` comment isn't already there — keep this idempotent across daily Routine runs): `Superseded by #<NEW_PR>. The newer versions in scope require public-API changes; work moved to next. This PR can be closed.` Leave the old PR open for the maintainer to close. **This is the single explicit exception to §10's "no duplicate bump PRs" rule** — see §10.
-   - Old PR was Path B → keep it on `next`; update in place.
+1. Decide whether to update in place or re-template:
+   - Old PR was safe and the delta from `<OLD_TARGET>` → `<NEW_TARGET>` adds only safe items → **update in place** (no template change).
+   - Old PR was safe but the additional versions in scope add risky items → categorization flips. **Update in place**: rename the PR title to the risky template (section 6), rewrite the body to the risky template, re-stamp the CHANGELOG entry as a risky bump (under `[Unreleased]`, `**(beta)**` qualifier). Branch name (`bump/pbl-<OLD>`) can stay as-is — it's a minor cosmetic mismatch with the conventional `-beta` suffix but doesn't break anything; alternatively the agent may open a fresh `bump/pbl-<NEW>-beta` branch and close the old PR with `Superseded by #<NEW_PR>` (only if a `Superseded by #` comment isn't already there — keep idempotent across daily runs). Prefer update-in-place unless the branch-name cosmetic bothers the maintainer; both are acceptable. **This update-in-place + re-template is the only path a single bump PR transitions through during its lifetime** — see §10.
+   - Old PR was risky → update in place (template already matches).
 2. Updating in place:
-   - Pull the branch locally and rebase its base (`main` or `next`) into it so it's current.
+   - Pull the branch locally and rebase `main` into it so it's current.
    - Bump `playBillingKtx` to the new latest.
    - Extend the CHANGELOG entry's release-notes summary to cover the newly-in-scope versions; widen the version-delta range in the PR body.
    - Re-run verification (`:billing:test :sample:assembleDebug :billing:lint`). Fix failures per section 7.
-   - Update the PR title to reflect the new `<NEW>` version. Update the body's Version delta, Migration guide (if a major boundary is now in scope), Categorization, Feature proposals deferred to follow-up issues (if any new ones were opened for the additional versions), and (for Path B) Risky items / Public API changes sections.
+   - Update the PR title to reflect the new `<NEW>` version. Update the body's Version delta, Migration guide (if a major boundary is now in scope), Categorization, Feature proposals deferred to follow-up issues (if any new ones were opened for the additional versions), and (for risky bumps) Risky items / Public API changes sections.
    - Force-push the updated branch with `git push --force-with-lease` (rebase rewrites history; `--force-with-lease` is preferred over `--force` because it refuses to clobber commits the agent hasn't seen).
    - Post a PR comment: `Refreshed: target bumped <OLD_TARGET> → <NEW_TARGET>; added <N> additional release-notes items to scope; verification re-run.`
 3. Send the IFTTT notification (section 11) noting the refresh: `Kanetik PBL update PR refreshed <OLD_TARGET> -> <NEW_TARGET>: <PR_URL>`.
 
-**Multiple open PRs match** (the common case is the Path A → Path B supersession above, but otherwise rare): treat the most recently updated one as authoritative. On each other matching PR, post a comment pointing at the authoritative PR (`Superseded by #<NUM>; this PR can be closed.`) — but skip the comment if such a comment from the agent is already present, so daily Routine runs don't pile up duplicate supersede comments. Do not auto-close — let the maintainer.
+**Multiple open PRs match** (rare — the daily-update flow normally produces only one open bump PR at a time, since re-categorization updates in place per the rule above): treat the most recently updated one as authoritative. On each other matching PR, post a comment pointing at the authoritative PR (`Superseded by #<NUM>; this PR can be closed.`) — but skip the comment if such a comment from the agent is already present, so daily Routine runs don't pile up duplicate supersede comments. Do not auto-close — let the maintainer.
 
 ### What "as good as possible" means here
 
@@ -157,14 +157,14 @@ For each version in scope, read **both** of these Google sources:
 
 Cross-reference the two. If the migration guide describes something the release notes didn't (or vice versa), treat that as a categorization signal — escalate to risky if there's any doubt. Then classify each change using the rubric below.
 
-### Safe (route to `main`, wrapper patch bump)
+### Safe (wrapper patch bump, tag `vX.Y.Z`)
 
 - Pure bug fix
 - Performance improvement
 - Internal refactor (PBL's own internals, no consumer-visible change)
 - Documentation-only change
 
-### Risky (route to `next`, wrapper minor or major beta)
+### Risky (wrapper minor or major beta, tag `vX.Y.Z-beta1`)
 
 - **Any deprecation** of an API the wrapper uses internally (`grep` the wrapper for the deprecated symbol — if found, route as risky even if it still compiles)
 - **Any removal** of an API
@@ -217,8 +217,8 @@ Default behavior, for every net-new PBL feature:
 
 **Zero-ambiguity exception (rare — default is still to open an issue):** if the new PBL API is unambiguously the wrapper's job to expose with no design choice required — most commonly a new overload of a method the wrapper already wraps, where the new overload's wrapped signature follows mechanically from the existing one — the agent **may** include it in the bump PR. When it does:
 
-- **Path B / `next` only.** Adding any new function to `com.kanetik.billing.*` — even a trivial mechanical overload — is a public-API change, and per §1's guardrails public-API changes are forbidden on Path A / `main`. If you're on Path A and an overload would qualify for this exception, treat it as a re-categorization mid-flow (see "Re-categorization mid-flow" later in this section): abandon the Path A bump and re-open the work on `next` per section 6. The branch-switching mechanics in section 7 apply even though the trigger here is the exception applying, not a test failure. Alternatively, drop the overload from the bump PR and open it as a feature-proposal issue instead, exactly like a non-trivial feature. On Path A the exception itself is **not available** in the current PR.
-- List every such addition under a "Net-new PBL surface included for parity" section in the PR body (Path B template only — section 6).
+- **Risky bumps only.** Adding any new function to `com.kanetik.billing.*` — even a trivial mechanical overload — is a public-API change, and per §1's guardrails public-API changes are forbidden on safe bumps. If you're on a safe bump and an overload would qualify for this exception, treat it as a re-categorization mid-flow (see "Re-categorization mid-flow" later in this section): re-template the PR as risky per section 7. Alternatively, drop the overload from the bump PR and open it as a feature-proposal issue instead, exactly like a non-trivial feature. On a safe bump the exception itself is **not available** in the current PR.
+- List every such addition under a "Net-new PBL surface included for parity" section in the PR body (risky template only — section 6).
 - For each, give a one-line rationale for why it was a mechanical add (e.g., "PBL added a `BillingClient.queryPurchasesAsync(QueryPurchasesParams, Continuation)` Kotlin-coroutine overload of the existing wrapped `queryPurchasesAsync(QueryPurchasesParams, PurchasesResponseListener)`; the wrapper's coroutine wrapper now delegates to the new overload — no design choice").
 - If you're under ~95% confident the add is mechanical: don't include it. Open the issue instead.
 
@@ -232,7 +232,7 @@ The cost of a deferred feature is "maintainer sees one extra issue in their inbo
 - Anything labeled "important" or "behavior change" in release notes that's hard to categorize
 - A change where the agent's confidence is < 80%
 
-When unsure, route as risky. Cost of a false-risky is "human reviews a PR that could have been simpler"; cost of a false-safe is a regression on `main`.
+When unsure, categorize as risky. Cost of a false-risky is "human reviews a PR that could have been simpler and ships as a beta tag instead of a stable patch"; cost of a false-safe is a regression that ships immediately as a stable patch tag.
 
 ### Multiple versions in scope
 
@@ -240,11 +240,11 @@ If multiple PBL versions accumulated since the last pin, take the **most-conserv
 
 ### Re-categorization mid-flow
 
-If the agent starts on Path A (safe) and discovers during the fix loop that the necessary fix requires public-API changes, the categorization **flips to risky**. Abandon the `main` branch work, switch to `next`, and follow Path B. Section 7 covers this transition explicitly.
+If the agent starts on a safe bump and discovers during the fix loop that the necessary fix requires public-API changes, the categorization **flips to risky**. No branch switch is needed — both safe and risky target `main`. Re-template the PR (title, body, CHANGELOG entry) to the risky format from section 6. Section 7 covers the mechanics of the transition explicitly.
 
 ---
 
-## 5. Path A — all-safe bump (target `main`)
+## 5. Safe bump — patch tag (target `main`)
 
 Branch from `main` as `bump/pbl-<NEW_VERSION>` (e.g., `bump/pbl-8.3.1`).
 
@@ -290,10 +290,10 @@ If anything fails: do **not** open a PR. Go to section 7 (Test failure handling)
   Reasoning:
   - <bullet for each change in release notes, with the safe-rationale>
 
-  (Path A never introduces net-new public surface in the wrapper — see
-  section 4's zero-ambiguity exception, which is Path B only. If a
+  (A safe bump never introduces net-new public surface in the wrapper — see
+  section 4's zero-ambiguity exception, which is risky-bumps only. If a
   trivial overload looks like it ought to be included, the categorization
-  flips to risky and the work moves to `next`.)
+  flips to risky — re-template the PR per section 7.)
 
   ## Feature proposals deferred to follow-up issues
   <if none>: None — no net-new PBL features in this version range.
@@ -320,25 +320,18 @@ After opening the PR: send the IFTTT notification (section 11).
 
 ---
 
-## 6. Path B — risky bump (target `next`)
+## 6. Risky bump — beta tag (target `main`)
 
-If the `next` branch doesn't exist, create it from `main` and push it before doing anything else:
-```bash
-git checkout -b next main
-git push origin next
-```
-Mention this branch creation in the PR body so the maintainer knows it's a first-time event.
-
-Branch from `next` as `bump/pbl-<NEW_VERSION>-beta` (e.g., `bump/pbl-8.5.0-beta`).
+Branch from `main` as `bump/pbl-<NEW_VERSION>-beta` (e.g., `bump/pbl-9.1.0-beta`).
 
 ### Edits
 
 1. `gradle/libs.versions.toml`: update `playBillingKtx`.
-2. **Internal code adjustments as needed.** Unlike Path A, Path B may include public-API changes:
+2. **Internal code adjustments as needed.** Unlike a safe bump, a risky bump may include public-API changes:
    - If a deprecated API the wrapper uses is still callable, prefer migrating to the new API rather than leaving a TODO. Be explicit in the PR body about why the migration was chosen.
    - If an API was *removed*, the agent migrates the wrapper. If the wrapper's public surface needs to change to absorb the removal, do it — but list every public-API change with a `**BREAKING:**` prefix in the PR body.
-   - **Net-new PBL features still go to feature-proposal issues, not into this PR** (see section 4's "Net-new PBL features" subsection). Path B is for absorbing risky upstream changes that affect what the wrapper already exposes, not for opportunistically expanding the wrapper's surface. The zero-ambiguity exception in section 4 still applies for trivial overloads of methods the wrapper already wraps.
-3. `CHANGELOG.md` on the `next` branch: add an entry under `## [Unreleased]`:
+   - **Net-new PBL features still go to feature-proposal issues, not into this PR** (see section 4's "Net-new PBL features" subsection). A risky bump is for absorbing risky upstream changes that affect what the wrapper already exposes, not for opportunistically expanding the wrapper's surface. The zero-ambiguity exception in section 4 still applies for trivial overloads of methods the wrapper already wraps.
+3. `CHANGELOG.md`: add an entry under `## [Unreleased]`:
    ```markdown
    ### Changed
 
@@ -353,21 +346,21 @@ Branch from `next` as `bump/pbl-<NEW_VERSION>-beta` (e.g., `bump/pbl-8.5.0-beta`
 
    - <bullet for each risky item, with link to release-notes section>
    ```
-4. **Do not** modify `[Unreleased]` on `main` for this work.
+   The entry sits under `[Unreleased]` (no dated version stamp) because the maintainer will tag a beta first (`vX.Y.Z-beta1`) and then GA (`vX.Y.Z`) only after dog-fooding. Stamping the dated section is the maintainer's call at tag time.
 
 ### Verification (must pass before opening the PR)
 
-Same as Path A: `./gradlew :billing:test :sample:assembleDebug :billing:lint`. If anything fails, go to section 7.
+Same as a safe bump: `./gradlew :billing:test :sample:assembleDebug :billing:lint`. If anything fails, go to section 7.
 
 ### Open the PR
 
 - **Title:** `build(deps): bump play-billing-ktx <OLD> → <NEW> (beta — risky changes flagged)`
-- **Base branch:** `next`
+- **Base branch:** `main`
 - **Body:**
   ```
-  Automated bump by daily PBL update Routine. Routed to `next` because the
-  release contains changes that warrant maintainer review before merging
-  to `main`.
+  Automated bump by daily PBL update Routine. Categorized as risky because the
+  release contains changes that warrant maintainer review before going GA — the
+  maintainer cuts a `-beta1` tag first to dog-food, then drops the suffix for GA.
 
   ## Version delta
   Pinned: <OLD>
@@ -376,7 +369,7 @@ Same as Path A: `./gradlew :billing:test :sample:assembleDebug :billing:lint`. I
   Migration guide: <URL if any major boundary in scope, else "N/A — no major boundary crossed">
 
   ## Categorization
-  Risky — minor or major beta on `next`.
+  Risky — minor or major beta, tag as `<NEXT_VERSION>-beta1` after merge.
 
   ### Risky items
   - <each risky change with: what it is, why it's risky, what the wrapper now does>
@@ -408,10 +401,6 @@ Same as Path A: `./gradlew :billing:test :sample:assembleDebug :billing:lint`. I
   <NEXT_VERSION>-beta1
   Rationale: <minor if API additive, major if any BREAKING items above>
 
-  ## Branch creation note (if applicable)
-  This PR is the first time the `next` branch was used. Created from `main` at
-  commit <sha> on <date>.
-
   ## Verification
   - :billing:test — 58 tests passed
   - :sample:assembleDebug — succeeded
@@ -421,9 +410,9 @@ Same as Path A: `./gradlew :billing:test :sample:assembleDebug :billing:lint`. I
   1. Read the risky items list and confirm the migration strategy for each.
   2. Audit the public API changes (each `**BREAKING:**` line).
   3. Triage any linked feature-proposal issues (separate from this PR).
-  4. Merge to `next` when satisfied with the bump itself.
-  5. Tag a `vX.Y.Z-beta1` release from `next` to publish the beta.
-  6. After dog-fooding the beta, fast-forward `main` to `next` and tag `vX.Y.Z` GA.
+  4. Merge when satisfied with the bump itself.
+  5. Tag `v<NEXT_VERSION>-beta1` from `main` to publish the beta.
+  6. After dog-fooding the beta, tag `v<NEXT_VERSION>` (no `-beta` suffix) from `main` to publish GA. Edit the `[Unreleased]` CHANGELOG section into a dated `[<NEXT_VERSION>] - <YYYY-MM-DD>` section at GA time.
   ```
 
 If the PR has unresolved questions about API shape or migration choice, mark as **draft** and post the specific questions in the PR description.
@@ -447,19 +436,16 @@ Order of investigation:
 
 If the conclusion is #3 (test is wrong), fix the test, but **explicitly note this in the PR body** so the maintainer can audit the test change.
 
-### Step 2 — fix on the appropriate branch
+### Step 2 — fix (and re-template if needed)
 
-If on Path A (current branch = `bump/pbl-<NEW>` from main):
-- If the fix is internal-only (no public API touched) and confined to the bump branch — apply it, re-run tests, continue.
-- If the fix requires public API changes — **the categorization flips to risky**:
-  1. Push the WIP commit to a temporary location if useful (or just stash/cherry-pick).
-  2. Delete the local `bump/pbl-<NEW>` branch.
-  3. Switch to `next` (creating from `main` if missing). Create `bump/pbl-<NEW>-beta` from `next`.
-  4. Reapply the bump + the fix on the new branch.
-  5. Run verification again.
-  6. Open the PR per Path B (section 6), explicitly noting in the body that the work was re-routed from Path A → Path B because the fix required public-API changes.
+If on a safe bump (current branch = `bump/pbl-<NEW>`):
+- If the fix is internal-only (no public API touched) — apply it, re-run tests, continue.
+- If the fix requires public API changes — **the categorization flips to risky**. Since both safe and risky bumps target `main`, no branch switch is strictly necessary. The agent has two acceptable options:
+  1. **Re-template in place (default).** Apply the fix on the existing `bump/pbl-<NEW>` branch. Rename the PR title to the risky template, swap the body to the risky template (section 6), and re-write the CHANGELOG entry to the risky shape (`[Unreleased]`, `**(beta)**` qualifier). The branch name keeps its non-`-beta` suffix — a minor cosmetic mismatch with the convention, called out in the PR body.
+  2. **Fresh branch.** Stash the bump + fix, create `bump/pbl-<NEW>-beta` from `main`, reapply, open a new PR per section 6, close the old PR with a comment pointing at the new one. Use this if the cosmetic branch-name drift in option (1) bothers the maintainer.
+- In both options: re-run verification before pushing. Note in the PR body that the categorization flipped mid-flow and why.
 
-If on Path B (current branch = `bump/pbl-<NEW>-beta` from next):
+If already on a risky bump (current branch = `bump/pbl-<NEW>-beta`):
 - Apply the fix (public API changes are allowed here).
 - Document each public-API change with a `**BREAKING:**` line in the PR body.
 - Re-run verification.
@@ -485,21 +471,24 @@ The wrapper's semver is driven by **what changed in the wrapper's public API**, 
 - Wrapper public API additive AND no minSdk change → **minor** (`0.1.0` → `0.2.0`)
 - Wrapper public API broke OR minSdk changed → **major** (`0.x` → `1.0.0`)
 
-For Path A (all-safe), it's always patch.
+For a safe bump, it's always patch.
 
-For Path B (risky), the agent picks based on the table above. Default is minor unless any `**BREAKING:**` items are listed in the PR body — then major.
+For a risky bump, the agent picks based on the table above. Default is minor unless any `**BREAKING:**` items are listed in the PR body — then major.
 
-`-beta` suffix is added on Path B PRs by default. The first beta is `-beta1`; subsequent attempts are `-beta2`, etc. The maintainer drops the suffix when cutting GA.
+`-beta` suffix is added on risky-bump PRs by default. The first beta is `-beta1`; subsequent attempts are `-beta2`, etc. The maintainer drops the suffix when cutting GA (`vX.Y.Z` from `main`, same branch the betas were tagged from).
 
 ---
 
 ## 9. Branch lifecycle
 
-- `main`: always represents the latest GA-shippable code. Path A PRs land here.
-- `next`: tracks the in-progress next minor or major. Path B PRs land here. Once a `next`-cycle ships GA, fast-forward `main` to `next` and (optionally) leave `next` empty until the next risky bump arrives.
-- `release/0.x`: created when v1 ships, for backports to the 0.x line. Out of scope for this playbook (manual maintenance).
+Single trunk, tag-driven pre-releases:
 
-The agent creates `next` if needed (first-time event); the agent never deletes branches.
+- `main`: the trunk. Both safe and risky bump PRs land here. Stable patches are tagged `vX.Y.Z`; betas are tagged `vX.Y.Z-beta1` (then `-beta2`, etc. if the maintainer iterates); GA after a beta cycle is tagged `vX.Y.Z` (no suffix) from the same `main` commit (or a later one if additional fixes landed). No parallel `next` branch — categorization (safe vs risky) determines tag flavor, not branch.
+- `bump/pbl-<NEW>`: short-lived branch for a safe bump, deleted after the PR merges.
+- `bump/pbl-<NEW>-beta`: short-lived branch for a risky bump, deleted after the PR merges.
+- `release/0.x`: would be created when v1 ships, for backports to the 0.x line. Out of scope for this playbook (manual maintenance).
+
+The agent never deletes branches; the maintainer (or GitHub's auto-delete-on-merge setting, if enabled) handles bump-branch cleanup.
 
 ---
 
@@ -510,12 +499,12 @@ The agent creates `next` if needed (first-time event); the agent never deletes b
 - No tag creation
 - No deps bumped other than `playBillingKtx`
 - **No PR (draft or otherwise) with a failing build or failing tests.** Fix first; if you can't fix in 3 attempts, open an issue instead.
-- **No duplicate bump PRs.** If an open `bump/pbl-*` PR exists, audit it (same target) or refresh it (stale target) per section 3 — never open a second one. **Single explicit exception:** when a stale-target refresh's new scope flips categorization Path A → Path B (section 3), the agent opens a fresh PR on `next` and leaves the old Path A PR open with a one-time `Superseded by #<NEW_PR>` comment for the maintainer to close. Subsequent daily runs must not repost that comment.
+- **No duplicate bump PRs.** If an open `bump/pbl-*` PR exists, audit it (same target) or refresh it (stale target) per section 3 — never open a second one. Re-categorization mid-flow (safe → risky, e.g. because a stale-target refresh adds risky items) is handled by updating the existing PR in place (rename title, re-template body, re-stamp CHANGELOG); the agent may instead open a fresh `-beta` branch and supersede the old PR if the branch-name cosmetic matters. Either way, only one open bump PR for a given target version at any time.
 - **Read both release notes AND the migration guide** for every version in scope. Migration guide is required reading when a major boundary is crossed.
-- **No auto-including net-new PBL features.** Open a feature-proposal issue and @-mention @kanetik (per section 4). Zero-ambiguity exception (Path B only): trivial overloads of methods the wrapper already wraps may be included in the bump PR, called out under "Net-new PBL surface included for parity." On Path A the exception is unavailable — even trivial overloads either go to an issue or flip the bump to Path B.
-- Public API changes allowed only on `next`, never on `main`. If a Path A fix needs public API changes, re-route to Path B.
+- **No auto-including net-new PBL features.** Open a feature-proposal issue and @-mention @kanetik (per section 4). Zero-ambiguity exception (risky bumps only): trivial overloads of methods the wrapper already wraps may be included in the bump PR, called out under "Net-new PBL surface included for parity." On a safe bump the exception is unavailable — even trivial overloads either go to an issue or flip the bump to risky.
+- Public API changes allowed only on risky bumps, never on safe bumps. If a safe-bump fix needs public API changes, flip the categorization to risky (no branch switch required — see section 7).
 - Draft PRs are for *ambiguity*, not for failures. Post the specific questions in the PR description.
-- When confidence < 80% on categorization, route as risky.
+- When confidence < 80% on categorization, categorize as risky.
 
 ---
 
@@ -537,7 +526,7 @@ The applet accepts a single text parameter via `{{Value1}}` — the playbook han
 
 1. Use `mcp__claude_ai_IFTTT__my_applets` to find an applet whose name matches `Kanetik PBL Update Notification` (or the name in the setup section above; if the applet is renamed, update both this playbook and the setup section).
 2. If found: use `mcp__claude_ai_IFTTT__run_action` (or the equivalent) to fire the applet with text content:
-   - For a PR: `Kanetik PBL update <OLD> -> <NEW> needs review: <PR_URL> [Path A | Path B-beta]`
+   - For a PR: `Kanetik PBL update <OLD> -> <NEW> needs review: <PR_URL> [safe | risky-beta]`
    - For a target-version refresh (existing PR updated because a newer PBL stable is out, per section 3 — **not** audit fixes or rebase-only refreshes, which don't notify): `Kanetik PBL update PR refreshed <OLD_TARGET> -> <NEW_TARGET>: <PR_URL>`
    - For a feature-proposal issue (per section 4): `Kanetik PBL <VERSION> feature proposal needs decision: <ISSUE_URL>` — fire one per feature-proposal issue
    - For an intervention issue (3 fix attempts failed, per section 7): `Kanetik PBL update <OLD> -> <NEW> needs intervention: <ISSUE_URL>`
@@ -583,14 +572,15 @@ stable release, while protecting consumers from breaking changes.
      version in scope (section 4). Migration guide is at
      https://developer.android.com/google/play/billing/migrate-<MAJOR>
      and is required reading when a major boundary is crossed.
-   - Categorizing the release as safe vs risky
+   - Categorizing the release as safe vs risky (both target `main`;
+     categorization picks PR template + tag flavor, not a base branch)
    - **Net-new PBL features get a feature-proposal issue, NOT inclusion in
      the bump PR (section 4).** Open one issue per feature, label it
      `question`, @-mention @kanetik, and leave the design call to the
      maintainer. Trivial overloads of already-wrapped methods are the
-     only exception — and that exception is Path B only, because any
-     new function in `com.kanetik.billing.*` is a public-API change.
-   - Branching (main vs next, creating next if needed)
+     only exception — and that exception is risky-bumps only, because
+     any new function in `com.kanetik.billing.*` is a public-API change.
+   - Branching from `main` (`bump/pbl-<NEW>` for safe, `bump/pbl-<NEW>-beta` for risky)
    - Editing libs.versions.toml + CHANGELOG.md
    - Running :billing:test, :sample:assembleDebug, :billing:lint
    - **Fixing failures rather than shipping a broken PR** (section 7)
@@ -609,23 +599,26 @@ Constraints — the playbook spells these out, but to be explicit:
 - No duplicate bump PRs. If a `bump/pbl-*` PR is already open, follow
   section 3: audit it (same target version) or refresh the existing
   branch to the new latest (stale target version). Never open a second
-  PR for the same bump. Single documented exception (section 3 / §10):
-  when a stale-target refresh's new scope flips categorization Path A
-  → Path B, open a fresh PR on `next` and leave the old Path A PR
-  open with a one-time, idempotent `Superseded by #<NEW_PR>` comment
-  for the maintainer to close.
+  PR for the same bump. Re-categorization mid-flow (safe → risky, e.g.
+  because a stale-target refresh adds risky items) is handled by
+  updating the existing PR in place (rename title, re-template body,
+  re-stamp CHANGELOG entry); the agent may instead open a fresh
+  `-beta` branch and supersede the old PR with a one-time, idempotent
+  `Superseded by #<NEW_PR>` comment if the branch-name cosmetic
+  matters. Either way, only one open bump PR at a time.
 - No auto-including net-new PBL features in the bump PR. Open a
   `[feat proposal]` GitHub issue per feature, labeled `question`,
   @-mention @kanetik, and let the maintainer decide whether/how to
-  expose it. Only exception (Path B only): trivial overloads of
-  methods the wrapper already wraps. On Path A the exception does
-  not apply — flip to Path B or open an issue.
+  expose it. Only exception (risky bumps only): trivial overloads of
+  methods the wrapper already wraps. On a safe bump the exception
+  does not apply — flip to risky or open an issue.
 - No PR (draft or otherwise) with a failing build or failing tests.
   Fix the underlying issue. After 3 fix attempts that don't work, open
   a GitHub issue instead and notify via IFTTT.
-- Public API changes are allowed on `next` (Path B) but never on `main`
-  (Path A). If a Path A fix turns out to need public-API changes, the
-  categorization flips and the work moves to `next`.
+- Public API changes are allowed on risky bumps but never on safe
+  bumps. If a safe-bump fix turns out to need public-API changes, the
+  categorization flips to risky — re-template the PR per section 7.
+  No branch switch required; both safe and risky target `main`.
 - When fixing test failures, default assumption is the wrapper code is
   wrong, not the test. Investigation order: PBL behavior change ->
   wrapper internal code -> test.
@@ -650,7 +643,7 @@ To dry-run the playbook locally without waiting for the Routine:
    - Temporarily edit `libs.versions.toml` to a known-old PBL pin, OR
    - Run against a fork / branch where the pin is older.
 2. Run the same steps the Routine does manually (shell commands above).
-3. Verify the agent opens the right PR against the right branch with the right body.
+3. Verify the agent opens the right PR against `main` with the right template (safe vs risky) and body.
 4. Verify the IFTTT notification fires.
 5. Close the PR; revert any local edits.
 


### PR DESCRIPTION
Follow-up to #30 (forwarded the PBL 9.0.0 bump from `next` to `main`).

Rewrites `docs/_internal/automated-update-playbook.md` so both safe and risky bumps target `main`. Categorization (safe vs risky) picks the PR template and the tag flavor the maintainer cuts after merge, not a base branch.

## Tag flavors

- **Safe bump** → tag `vX.Y.Z` from `main` after merge. (Unchanged.)
- **Risky bump** → tag `vX.Y.Z-beta1` from `main` after merge; dog-food; tag `vX.Y.Z` (no `-beta` suffix) from `main` for GA. (Replaces the old "merge to next, tag from next, fast-forward main to next at GA" dance.)

## Section-by-section

- **§1, §3, §4, §10, §12**: relabel "Path A / Path B" as "safe / risky"; drop every "route to next" / "route to main" reference.
- **§5**: rename "Path A — all-safe bump (target main)" → "Safe bump — patch tag (target main)". Otherwise unchanged.
- **§6**: rename "Path B — risky bump (target next)" → "Risky bump — beta tag (target main)". Drops the "create next branch if missing" preamble, changes the base branch in the PR template from `next` to `main`, rewrites the body intro and the "what the maintainer should do" steps (tag from `main`, no fast-forward step).
- **§7**: re-categorization mid-flow is now a re-template in place (rename title, swap body to risky template, re-stamp CHANGELOG) rather than a branch switch. Agent may instead open a fresh `-beta` branch and supersede the old PR — both acceptable, agent picks based on whether the branch-name cosmetic bothers the maintainer.
- **§9**: branch lifecycle reduces to "main + short-lived bump branches". Explicitly notes "no parallel `next` branch" so the model is unambiguous.

No section renumbering — every section keeps its original number and purpose; only the routing language and a few section titles changed.

## After merge

- Delete remote branches: `next`, `bump/pbl-9.0.0-beta`, `claude/great-heisenberg-F0fMM`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)