### PR TITLE
feat(entitlement)!: generify EntitlementCache on K + neutral framing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,86 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3] - 2026-05-25
+
+### Breaking
+
+- **`EntitlementCache` is now generic on `K : Any`.** Previously the cache
+  modeled a single binary entitlement — fine for "premium unlock" apps,
+  wrong for any app with multiple non-consumable SKUs (a game with several
+  unlockable upgrades, an app with a Pro toolkit *and* an expansion pack,
+  etc.). The new shape is `EntitlementCache<K>` where `K` is whatever your
+  app uses to discriminate entitlements (`Unit` for the single-flag case,
+  `String` for product-ID-keyed maps, an `enum class` or sealed class for
+  named entitlements). The state map is `StateFlow<Map<K, EntitlementState>>`;
+  per-key access via the new `stateFor(key: K): Flow<EntitlementState>`
+  convenience.
+
+  - `productPredicate: (Purchase) -> Boolean` renamed to
+    `productKeySelector: (Purchase) -> K?` — returning `null` means
+    "this purchase doesn't grant any tracked entitlement" (use this for
+    consumables and any other ignored SKUs).
+  - `EntitlementStorage` is now `EntitlementStorage<K>`:
+    `readAll(): Map<K, EntitlementSnapshot>` + `write(key: K, snapshot: EntitlementSnapshot)`.
+    Single-snapshot implementations from 0.1.2 need to be ported to the
+    per-key map shape.
+  - `SignedEntitlementStorage` is now `SignedEntitlementStorage<K>` with
+    a required `keyToStorageId: (K) -> String` lambda — the serialized key
+    is used as the lookup ID in `SignatureStore` and is also included in
+    the v2 canonical bytes (cross-key signature swaps now fail verification).
+  - `SignatureStore` is now per-entitlement-key:
+    `readSignature(entitlementKey: String) / writeSignature(entitlementKey, signature) / clearSignature(entitlementKey)`.
+    The bundled `SharedPreferencesSignatureStore` stores blobs under
+    `"signature:" + entitlementKey` — distinct from the v0.1.2 `"signature"`
+    key, so the first read after upgrade fires `TamperEvent.MissingSignature`
+    once per entitlement and the recovery sweep re-confirms truth.
+  - `migrateUnsignedSnapshot` now takes `entitlementKey: String` +
+    `entitlementCacheKey: K` parameters so consumers running their own
+    pre-upgrade migration can target each key.
+  - `SnapshotCanonicalBytes` bumped to v2 (key included in canonical
+    encoding). v1 sigs continue to verify on read (the v1 encoder still
+    exists and ignores the key), so v0.1.2 single-entitlement consumers
+    upgrading with `K = Unit` and an empty `keyToStorageId` see no spurious
+    `InvalidSignature` events.
+  - `onTamperDetected` callback signature changed from
+    `(TamperEvent) -> Unit` to `(entitlementKey: String, TamperEvent) -> Unit`.
+
+  Migration for single-entitlement consumers: pick `K = Unit` (or a `data object`
+  key), have `productKeySelector` return that key for the matching product
+  and `null` otherwise, and port your `EntitlementStorage` to read/write a
+  one-entry map. The single-line `stateFor(yourKey)` returns the same
+  per-key `Flow<EntitlementState>` you'd previously bound to the UI.
+
+### Added
+
+- **`OneTimePurchaseOfferDetails.isPreorder` extension property.** Sugar
+  over PBL 8.1+'s `getPreorderDetails()` null-check, for use in
+  `toOneTimeFlowParams`'s `offerSelector`. New
+  [Pre-order / multi-offer products](https://kanetik.github.io/billing-library/guides/multi-offer-products/)
+  guide entry covers the pre-order pending-fulfillment / cancellation
+  caveats.
+- **Consumables ledger guide.** New
+  [docs page](https://kanetik.github.io/billing-library/guides/consumables/)
+  documenting the wallet-on-the-side pattern for consumable SKUs (coins,
+  fuel, gems) — explicitly distinct from `EntitlementCache`, with a
+  worked example showing how a multi-quantity consume + grant works
+  alongside `productKeySelector` returning `null` for consumables.
+- **Docs sweep: example framing.** KDoc and guide examples updated from
+  "premium unlock" framing to use-case-agnostic naming (one non-consumable
+  upgrade + one consumable currency pack, multi-entitlement games, etc.).
+  No API impact; aimed at first-time readers who weren't building a
+  premium-unlock app and bounced off the previous framing.
+
+### Notes
+
+- The original v0.1.3 scope included a `setPurchaseQuantity` knob on
+  `toOneTimeFlowParams` — dropped because PBL 9 doesn't expose
+  `setPurchaseQuantity` on `BillingFlowParams.ProductDetailsParams.Builder`.
+  In PBL 9, multi-quantity is Play-Console-flag + Play-dialog-driven only;
+  the client reads `purchase.quantity` on the way back. The
+  [Multi-quantity purchases](https://kanetik.github.io/billing-library/guides/multi-quantity/)
+  guide was updated to make this explicit.
+
 ## [0.1.2] - 2026-05-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,9 +77,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   No API impact; aimed at first-time readers who weren't building a
   premium-unlock app and bounced off the previous framing.
 
-### Notes
+### Risky items flagged for follow-up
 
-- The original v0.1.3 scope included a `setPurchaseQuantity` knob on
+- **PBL 9 dropped client-side multi-quantity control.** The original v0.1.3
+  scope included a `setPurchaseQuantity` knob on
   `toOneTimeFlowParams` — dropped because PBL 9 doesn't expose
   `setPurchaseQuantity` on `BillingFlowParams.ProductDetailsParams.Builder`.
   In PBL 9, multi-quantity is Play-Console-flag + Play-dialog-driven only;

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A coroutine-first wrapper around [Google Play Billing Library 9.x](https://devel
 
 ```kotlin
 dependencies {
-    implementation("com.kanetik.billing:billing:0.1.2")
+    implementation("com.kanetik.billing:billing:0.1.3")
 }
 ```
 
@@ -76,7 +76,7 @@ class CheckoutActivity : ComponentActivity() {
             QueryProductDetailsParams.newBuilder()
                 .setProductList(listOf(
                     QueryProductDetailsParams.Product.newBuilder()
-                        .setProductId("premium_lifetime")
+                        .setProductId("pro_toolkit")
                         .setProductType(BillingClient.ProductType.INAPP)
                         .build()
                 ))
@@ -88,8 +88,8 @@ class CheckoutActivity : ComponentActivity() {
 
     private suspend fun handle(purchase: Purchase) {
         when (val r = billing.handlePurchase(purchase, consume = false)) {
-            HandlePurchaseResult.Success -> grantPremium()
-            HandlePurchaseResult.AlreadyAcknowledged -> grantPremium() // safe — no PBL call needed
+            HandlePurchaseResult.Success -> grantEntitlement()
+            HandlePurchaseResult.AlreadyAcknowledged -> grantEntitlement() // safe — no PBL call needed
             HandlePurchaseResult.NotPurchased -> {} // pending — wait for terminal state
             HandlePurchaseResult.NotOwned -> {} // Play says not owned — defer to grace/revoke logic
             is HandlePurchaseResult.Failure -> showError(r.exception.userFacingCategory)
@@ -105,7 +105,8 @@ A few things are worth a read once you're past the smoke test, especially if Pla
 
 - [Purchase recovery](https://kanetik.github.io/billing-library/guides/purchase-recovery/) — what the two `PurchaseEvent` tiers actually are, why acknowledgement is a three-day cliff, and what the auto-sweep does about it. Probably the most important read in the docs.
 - [Error handling](https://kanetik.github.io/billing-library/guides/error-handling/) — the typed exception surface and which response codes the library retries automatically.
-- [EntitlementCache](https://kanetik.github.io/billing-library/guides/entitlement-cache/) — opt-in state machine for "is the user entitled right now," including signed/tamper-resistant storage.
+- [EntitlementCache](https://kanetik.github.io/billing-library/guides/entitlement-cache/) — opt-in `EntitlementCache<K>` state machine for "is the user entitled to X right now," per-key. Works for single-entitlement (`K = Unit`) and multi-entitlement apps (game with several SKUs, multiple non-consumable upgrades, etc.). Signed/tamper-resistant storage included.
+- [Consumables ledger](https://kanetik.github.io/billing-library/guides/consumables/) — the wallet-on-the-side pattern for SKUs that are credits, not entitlements (coins, fuel, etc.).
 
 ## Where to go next
 

--- a/billing/build.gradle.kts
+++ b/billing/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 // .github/workflows/publish.yml). Local builds get the SNAPSHOT default so
 // nothing accidentally publishes as a release version off main.
 group = "com.kanetik.billing"
-version = (findProperty("VERSION_NAME") as String?) ?: "0.1.2-SNAPSHOT"
+version = (findProperty("VERSION_NAME") as String?) ?: "0.1.3-SNAPSHOT"
 
 kotlin {
     // JVM 11 keeps the AAR consumable by any Android consumer on JDK 11+.

--- a/billing/src/main/kotlin/com/kanetik/billing/BillingActions.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/BillingActions.kt
@@ -160,15 +160,16 @@ public interface BillingActions {
      *
      * Granting entitlement on a failed acknowledge is the most common Play
      * Billing bug: caller writes `runCatching { handlePurchase(...) }` and
-     * `grantPremium()` outside the `.onSuccess { }` branch, Play auto-refunds
-     * the unacknowledged purchase within ~3 days, and the user's premium
-     * silently evaporates. Returning [HandlePurchaseResult] makes the failure
-     * case a sealed-type variant the compiler nudges callers to handle:
+     * `grantEntitlement()` outside the `.onSuccess { }` branch, Play
+     * auto-refunds the unacknowledged purchase within ~3 days, and the
+     * paid-for feature silently evaporates. Returning [HandlePurchaseResult]
+     * makes the failure case a sealed-type variant the compiler nudges callers
+     * to handle:
      *
      * ```
      * when (val r = billing.handlePurchase(purchase, consume = false)) {
-     *     HandlePurchaseResult.Success -> grantPremium()
-     *     HandlePurchaseResult.AlreadyAcknowledged -> grantPremium() // no PBL call made
+     *     HandlePurchaseResult.Success -> grantEntitlement()
+     *     HandlePurchaseResult.AlreadyAcknowledged -> grantEntitlement() // no PBL call made
      *     HandlePurchaseResult.NotPurchased -> {} // pending — wait
      *     HandlePurchaseResult.NotOwned -> {} // Play says not owned — defer to grace/revoke
      *     is HandlePurchaseResult.Failure -> showError(r.exception.userFacingCategory)

--- a/billing/src/main/kotlin/com/kanetik/billing/BillingPurchaseUpdatesOwner.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/BillingPurchaseUpdatesOwner.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.flow.Flow
  * Stream of purchase events pushed by Play Billing — the coroutine-side analogue of
  * [com.android.billingclient.api.PurchasesUpdatedListener].
  *
- * Collect this flow in your premium / entitlement layer to react to every purchase
+ * Collect this flow in your entitlement / wallet layer to react to every purchase
  * event. Branch on the [PurchaseEvent] sealed-interface roots:
  *  - [OwnedPurchases] (`Live`, `Recovered`) — owned-state events. Hand each
  *    purchase to [com.kanetik.billing.BillingActions.handlePurchase] and

--- a/billing/src/main/kotlin/com/kanetik/billing/HandlePurchaseResult.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/HandlePurchaseResult.kt
@@ -14,8 +14,8 @@ import com.kanetik.billing.exception.BillingException
  *
  * ```
  * when (val r = billing.handlePurchase(purchase, consume = false)) {
- *     HandlePurchaseResult.Success -> grantPremium()              // safe: ack landed
- *     HandlePurchaseResult.AlreadyAcknowledged -> grantPremium()    // safe: ack already in place
+ *     HandlePurchaseResult.Success -> grantEntitlement()           // safe: ack landed
+ *     HandlePurchaseResult.AlreadyAcknowledged -> grantEntitlement() // safe: ack already in place
  *     HandlePurchaseResult.NotPurchased -> {}                     // pending — wait for terminal state
  *     HandlePurchaseResult.NotOwned -> {}                          // stale snapshot — defer to grace/revoke
  *     is HandlePurchaseResult.Failure -> {

--- a/billing/src/main/kotlin/com/kanetik/billing/entitlement/EntitlementCache.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/entitlement/EntitlementCache.kt
@@ -255,8 +255,10 @@ public class EntitlementCache<K : Any>(
     /**
      * The current entitlement state per key. Keys absent from the map are
      * implicitly [EntitlementState.Revoked] (the cache hasn't observed a
-     * granting purchase for them). Empty until [start] hydrates from storage
-     * and the first event arrives.
+     * granting purchase for them). Empty until [start] runs hydration — if
+     * storage holds snapshots, [start] populates [state] from them before
+     * returning; if storage is empty, [state] stays empty until the first
+     * granting purchase is observed.
      */
     public val state: StateFlow<Map<K, EntitlementState>> = _state.asStateFlow()
 

--- a/billing/src/main/kotlin/com/kanetik/billing/entitlement/EntitlementCache.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/entitlement/EntitlementCache.kt
@@ -43,7 +43,7 @@ import kotlinx.coroutines.sync.withLock
  *  - **One non-consumable unlock** (e.g. "ad removal"): `K = Unit` with a
  *    `productKeySelector` that returns `Unit` for the matching product ID,
  *    `null` otherwise. The state map collapses to `{Unit -> ...}`; use
- *    [stateFor]`(Unit)` for ergonomics.
+ *    [stateFor] with `Unit` for ergonomics.
  *  - **Multiple non-consumable upgrades** (e.g. a game with a "Pro toolkit"
  *    and a separate "Expansion pack" SKU): `K = String` with the product ID,
  *    or an `enum class Entitlement { PRO_TOOLKIT, EXPANSION }`.
@@ -550,17 +550,26 @@ public class EntitlementCache<K : Any>(
      * grace — Play has explicitly revoked).
      */
     private fun handleRevoked(event: PurchaseRevoked): List<Pair<K, EntitlementSnapshot>> {
+        // Two-pass: collect matching keys first, then mutate via
+        // transitionToRevoked. Updating lastConfirmedSnapshots[key] for an
+        // already-present key is technically safe under HashMap's iterator
+        // (no structural modification), but the pattern is brittle — a
+        // future edit to transitionToRevoked could add a structural change
+        // (a new key, a removal) and break iteration. Iterate a snapshot of
+        // the matching keys instead so the transition is decoupled from the
+        // iteration.
         val now = clock()
-        val results = ArrayList<Pair<K, EntitlementSnapshot>>()
-        for ((key, confirmed) in lastConfirmedSnapshots) {
-            if (confirmed.purchaseToken == event.purchaseToken) {
-                val snapshot = EntitlementSnapshot(
-                    isEntitled = false,
-                    confirmedAtMs = now,
-                    purchaseToken = event.purchaseToken,
-                )
-                results.add(key to transitionToRevoked(key, snapshot))
-            }
+        val matchingKeys = lastConfirmedSnapshots
+            .filter { (_, confirmed) -> confirmed.purchaseToken == event.purchaseToken }
+            .keys.toList()
+        val results = ArrayList<Pair<K, EntitlementSnapshot>>(matchingKeys.size)
+        for (key in matchingKeys) {
+            val snapshot = EntitlementSnapshot(
+                isEntitled = false,
+                confirmedAtMs = now,
+                purchaseToken = event.purchaseToken,
+            )
+            results.add(key to transitionToRevoked(key, snapshot))
         }
         return results
     }

--- a/billing/src/main/kotlin/com/kanetik/billing/entitlement/EntitlementCache.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/entitlement/EntitlementCache.kt
@@ -10,16 +10,18 @@ import com.kanetik.billing.exception.BillingException
 import com.kanetik.billing.logging.BillingLogger
 import androidx.annotation.AnyThread
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
@@ -27,45 +29,71 @@ import kotlinx.coroutines.sync.withLock
  * Opt-in entitlement state machine wrapping
  * [com.kanetik.billing.BillingPurchaseUpdatesOwner.observePurchaseUpdates].
  *
- * Centralizes the `(isEntitled, lastConfirmedTs, source)` bookkeeping that
- * every consumer ends up reinventing on top of the raw `PurchaseEvent`
- * stream. Consumers that want a simple `StateFlow<EntitlementState>` they can
- * collect from a ViewModel get one; consumers that need the raw event stream
- * for custom logic continue to use `observePurchaseUpdates()` directly.
+ * Centralizes the `(isEntitled, lastConfirmedTs, source) per entitlement key`
+ * bookkeeping that every consumer ends up reinventing on top of the raw
+ * `PurchaseEvent` stream. Consumers that want a simple
+ * `StateFlow<Map<K, EntitlementState>>` they can collect from a ViewModel get
+ * one; consumers that need the raw event stream for custom logic continue to
+ * use `observePurchaseUpdates()` directly.
+ *
+ * ## Generic on K
+ *
+ * `K` is whatever type your app uses to discriminate entitlements:
+ *
+ *  - **One non-consumable unlock** (e.g. "ad removal"): `K = Unit` with a
+ *    `productKeySelector` that returns `Unit` for the matching product ID,
+ *    `null` otherwise. The state map collapses to `{Unit -> ...}`; use
+ *    [stateFor]`(Unit)` for ergonomics.
+ *  - **Multiple non-consumable upgrades** (e.g. a game with a "Pro toolkit"
+ *    and a separate "Expansion pack" SKU): `K = String` with the product ID,
+ *    or an `enum class Entitlement { PRO_TOOLKIT, EXPANSION }`.
+ *  - **Multiple consumable wallets** (coins, gems, fuel): tracking the
+ *    *wallet balance* is **not** what this cache does — see the
+ *    [Consumables ledger guide](https://kanetik.github.io/billing-library/guides/consumables/).
+ *    The cache is for boolean "user is currently entitled to feature X"
+ *    state. Each consumable purchase is a wallet credit (see [handleObservation]'s
+ *    docs), not an entitlement.
+ *
+ * The cache holds one [EntitlementState] per key in [state]. Keys absent from
+ * the map are implicitly [EntitlementState.Revoked] (the cache hasn't observed
+ * a granting purchase for them).
  *
  * ## What it does
  *
- *  - Hydrates from a consumer-provided [EntitlementStorage] so premium UI can
- *    render before the first network round-trip lands.
- *  - Treats [OwnedPurchases.Live] and [OwnedPurchases.Recovered] as
- *    grant-only signals: a match against `productPredicate` transitions to
+ *  - Hydrates from a consumer-provided [EntitlementStorage] (one snapshot per
+ *    key) so gated UI can render before the first network round-trip lands.
+ *  - Treats [OwnedPurchases.Live] and [OwnedPurchases.Recovered] as grant-only
+ *    signals: for each [Purchase] in `purchaseState == PURCHASED`, applies
+ *    [productKeySelector]; a non-null result transitions that key to
  *    [EntitlementState.Granted]. A non-match does **not** revoke (Live can
- *    carry empty/UNSPECIFIED_STATE callbacks; Recovered emits only the
- *    unacked subset). Revocation flows through [PurchaseRevoked] and grace
- *    expiry — see "Sealed-when handling" below.
- *  - On [FlowOutcome.Failure], moves to [EntitlementState.InGrace] for a
- *    window determined by the failure type and your [GracePolicy] — premium
- *    keeps working through a brief outage instead of being yanked the
- *    moment Play stops responding.
- *  - Re-evaluates grace expiry on every emission and on a periodic tick, so
- *    an extended outage correctly transitions InGrace → Revoked even when
- *    no further updates arrive.
+ *    carry empty/UNSPECIFIED_STATE callbacks; Recovered emits only the unacked
+ *    subset). Revocation flows through [PurchaseRevoked] and grace expiry —
+ *    see "Sealed-when handling" below.
+ *  - On [FlowOutcome.Failure], moves every currently-Granted or InGrace key
+ *    to [EntitlementState.InGrace] for a window determined by the failure
+ *    type and your [GracePolicy] — gated features keep working through a
+ *    brief outage instead of being yanked the moment Play stops responding.
+ *  - Re-evaluates grace expiry on every emission and on a periodic tick, per
+ *    key, so an extended outage correctly transitions InGrace → Revoked even
+ *    when no further updates arrive.
  *  - Persists every confirmed observation through [EntitlementStorage.write]
  *    so the next process can hydrate. Grace is not persisted (re-derived
  *    from the most recent confirmed `confirmedAtMs`).
  *
  * ## Hydration staleness
  *
- * On [start], the cache hydrates from [storage] and trusts the persisted
+ * On [start], the cache hydrates from [storage] and trusts each persisted
  * Granted snapshot indefinitely — there is no max-age check at hydration
  * time. A Granted snapshot persisted six months ago in a previous session
  * still hydrates as Granted today. This is intentional: the cache treats
  * Play as the authoritative source of revocation signals, not the local
- * clock. Three things can invalidate a stale-but-hydrated Granted state:
+ * clock. Three things can invalidate a stale-but-hydrated Granted state for
+ * a given key:
  *
- *  1. A [PurchaseRevoked] event matching the cached `purchaseToken` —
- *     consumers wire this through `emitExternalRevocation` from their
- *     RTDN/FCM pipeline; this is the primary revocation channel.
+ *  1. A [PurchaseRevoked] event whose `purchaseToken` matches the cached
+ *     snapshot's `purchaseToken` for that key — consumers wire this through
+ *     `emitExternalRevocation` from their RTDN/FCM pipeline; this is the
+ *     primary revocation channel.
  *  2. A [FlowOutcome.Failure] event whose grace window
  *     (`confirmedAtMs + window`) is already in the past — `handleFailure`
  *     compares the anchor against `clock()` and revokes immediately if
@@ -74,9 +102,9 @@ import kotlinx.coroutines.sync.withLock
  *  3. Consumer-side max-age before passing the snapshot to the cache —
  *     apps that need a hard ceiling (e.g., "any snapshot older than 90
  *     days is suspicious") can implement that in their [EntitlementStorage]
- *     `read()` by returning null when the snapshot's `confirmedAtMs` is
- *     too old. The cache treats null as "no prior snapshot" and starts
- *     in default Revoked.
+ *     `readAll()` by filtering out snapshots whose `confirmedAtMs` is
+ *     too old. The cache treats absent keys as "no prior snapshot" and
+ *     starts them in default Revoked.
  *
  * The deliberate omission of a built-in max-age policy avoids picking an
  * arbitrary number that wouldn't fit every app's threat model.
@@ -92,14 +120,18 @@ import kotlinx.coroutines.sync.withLock
  *    effects.
  *  - It does not verify purchase signatures. Pair with
  *    [com.kanetik.billing.security.PurchaseVerifier] in your collector if
- *    you need that — the cache treats every passing predicate as authoritative.
+ *    you need that — the cache treats every passing selector match as
+ *    authoritative.
+ *  - It does not track consumable wallet balances. See the
+ *    [Consumables ledger guide](https://kanetik.github.io/billing-library/guides/consumables/).
  *
  * ## Wiring
  *
  * ```
- * class PremiumViewModel(
+ * // Single binary entitlement (ad removal):
+ * class AdRemovalViewModel(
  *     billing: BillingRepository,
- *     storage: EntitlementStorage,
+ *     storage: EntitlementStorage<Unit>,
  * ) : ViewModel() {
  *     private val cache = EntitlementCache(
  *         purchasesUpdates = billing.observePurchaseUpdates(),
@@ -108,20 +140,39 @@ import kotlinx.coroutines.sync.withLock
  *             billingUnavailableMs = TimeUnit.HOURS.toMillis(72),
  *             transientFailureMs   = TimeUnit.HOURS.toMillis(6),
  *         ),
- *         productPredicate = { it.products.contains("premium_lifetime") },
+ *         productKeySelector = { p -> if (p.products.contains("ad_removal")) Unit else null },
  *     )
- *
- *     init {
- *         // start() is suspend so hydration completes before it returns —
- *         // the first read of cache.state.value reflects the persisted
- *         // snapshot, not the default Revoked. Launch it from viewModelScope
- *         // so init isn't blocked.
- *         viewModelScope.launch { cache.start(viewModelScope) }
- *     }
- *
- *     val isPremium: StateFlow<Boolean> = cache.state
- *         .map { it !is EntitlementState.Revoked }
+ *     init { viewModelScope.launch { cache.start(viewModelScope) } }
+ *     val adsRemoved: StateFlow<Boolean> = cache.stateFor(Unit)
+ *         .map { it is EntitlementState.Granted || it is EntitlementState.InGrace }
  *         .stateIn(viewModelScope, SharingStarted.Eagerly, false)
+ * }
+ * ```
+ *
+ * ```
+ * // Multi-entitlement (game with non-consumable upgrades):
+ * enum class GameEntitlement { PRO_TOOLKIT, EXPANSION_PACK }
+ *
+ * class ShopViewModel(
+ *     billing: BillingRepository,
+ *     storage: EntitlementStorage<GameEntitlement>,
+ * ) : ViewModel() {
+ *     private val cache = EntitlementCache(
+ *         purchasesUpdates = billing.observePurchaseUpdates(),
+ *         storage = storage,
+ *         gracePolicy = GracePolicy(...),
+ *         productKeySelector = { p ->
+ *             when {
+ *                 "pro_toolkit" in p.products -> GameEntitlement.PRO_TOOLKIT
+ *                 "expansion_pack" in p.products -> GameEntitlement.EXPANSION_PACK
+ *                 else -> null   // consumables (currency packs) bypass the cache
+ *             }
+ *         },
+ *     )
+ *     init { viewModelScope.launch { cache.start(viewModelScope) } }
+ *
+ *     val hasProToolkit: Flow<Boolean> = cache.stateFor(GameEntitlement.PRO_TOOLKIT)
+ *         .map { it is EntitlementState.Granted || it is EntitlementState.InGrace }
  * }
  * ```
  *
@@ -134,22 +185,25 @@ import kotlinx.coroutines.sync.withLock
  *
  * The cache reacts to four event paths:
  *  - [OwnedPurchases.Live] / [OwnedPurchases.Recovered]: **grant-only**.
- *    A match against [productPredicate] transitions to [EntitlementState.Granted]
- *    and persists the snapshot. A non-match on either does **not** revoke —
+ *    For each PURCHASED-state purchase, [productKeySelector] is applied; a
+ *    non-null result transitions that key to [EntitlementState.Granted] and
+ *    persists. A non-match (selector returns null) does **not** revoke —
  *    `Live` can carry `UNSPECIFIED_STATE` entries or products unrelated to
- *    [productPredicate], and `Recovered` only emits the `PURCHASED && !isAcknowledged`
- *    subset filtered against the library's acknowledgedTokens set, so an
- *    already-acked entitling purchase will never appear there. Treating
- *    either as authoritative for revocation would falsely revoke users
- *    whose entitling purchase has already been acknowledged.
- *  - [FlowOutcome.Failure]: triggers [EntitlementState.InGrace] (or revokes
+ *    any tracked entitlement, and `Recovered` only emits the
+ *    `PURCHASED && !isAcknowledged` subset filtered against the library's
+ *    acknowledgedTokens set, so an already-acked entitling purchase will
+ *    never appear there. Treating either as authoritative for revocation
+ *    would falsely revoke users whose entitling purchase has already been
+ *    acknowledged.
+ *  - [FlowOutcome.Failure]: triggers [EntitlementState.InGrace] for every
+ *    currently-Granted or InGrace key (or transitions them to Revoked
  *    immediately if the policy window is zero or has already elapsed since
- *    the last confirmation).
+ *    that key's last confirmation).
  *  - [com.kanetik.billing.PurchaseRevoked]: when `event.purchaseToken`
- *    matches the cached snapshot's `purchaseToken`, transitions to
- *    [EntitlementState.Revoked] immediately (no grace; Play has explicitly
+ *    matches *any* cached snapshot's `purchaseToken`, that key transitions
+ *    to [EntitlementState.Revoked] immediately (no grace; Play has explicitly
  *    revoked). Consumers wire `emitExternalRevocation` against their
- *    RTDN→FCM pipeline — see the README "Server-driven revocation" section.
+ *    RTDN→FCM pipeline.
  *
  * The remaining [FlowOutcome] variants ([FlowOutcome.Pending],
  * [FlowOutcome.Canceled], [FlowOutcome.ItemAlreadyOwned],
@@ -160,29 +214,31 @@ import kotlinx.coroutines.sync.withLock
  * @param purchasesUpdates The hot purchase-update stream — typically
  *   [com.kanetik.billing.BillingPurchaseUpdatesOwner.observePurchaseUpdates].
  *   The cache subscribes inside [start].
- * @param storage Persistence layer. See [EntitlementStorage] for the
- *   contract.
- * @param gracePolicy How long to keep treating the user as entitled after a
+ * @param storage Persistence layer. See [EntitlementStorage] for the contract.
+ * @param gracePolicy How long to keep treating a key as entitled after a
  *   [FlowOutcome.Failure]. Pass [GracePolicy.None] to disable grace.
- * @param productPredicate Filter applied to each [Purchase] in an
- *   [OwnedPurchases.Live] / [OwnedPurchases.Recovered] event to decide
- *   whether it grants entitlement. Typical shapes:
- *   `{ it.products.contains("premium_lifetime") }` for a single SKU,
- *   `{ it.products.any { id -> id in premiumIds } }` for a SKU set.
+ * @param productKeySelector Maps each [Purchase] to the entitlement key it
+ *   grants, or `null` if the purchase doesn't grant any tracked entitlement.
+ *   Typical shapes:
+ *   `{ p -> if ("pro_toolkit" in p.products) Unit else null }` for a single
+ *   non-consumable unlock; `{ p -> p.products.firstOrNull()?.takeIf { it in tracked } }`
+ *   for a `K = String` map keyed by product ID; a `when` over known SKUs for
+ *   an `enum` or sealed-class key. Consumables and any other products you
+ *   don't want the cache to track return `null`.
  * @param clock Time source. Defaults to `System.currentTimeMillis`. Inject a
  *   deterministic source in tests so grace-window assertions don't depend
  *   on real time.
- * @param graceTickIntervalMs How often the periodic tick re-evaluates an
- *   active [EntitlementState.InGrace] state to detect grace expiry. Defaults
- *   to 60 seconds — fine-grained enough that grace never overstays by more
- *   than a minute, coarse enough to be free of cost. Set lower in tests
- *   driving a virtual clock.
+ * @param graceTickIntervalMs How often the periodic tick re-evaluates active
+ *   [EntitlementState.InGrace] keys to detect grace expiry. Defaults to 60
+ *   seconds — fine-grained enough that grace never overstays by more than a
+ *   minute, coarse enough to be free of cost. Set lower in tests driving a
+ *   virtual clock.
  */
-public class EntitlementCache(
+public class EntitlementCache<K : Any>(
     private val purchasesUpdates: Flow<PurchaseEvent>,
-    private val storage: EntitlementStorage,
+    private val storage: EntitlementStorage<K>,
     private val gracePolicy: GracePolicy,
-    private val productPredicate: (Purchase) -> Boolean,
+    private val productKeySelector: (Purchase) -> K?,
     private val clock: () -> Long = System::currentTimeMillis,
     private val graceTickIntervalMs: Long = DEFAULT_GRACE_TICK_INTERVAL_MS,
     private val logger: BillingLogger = BillingLogger.Noop,
@@ -194,61 +250,63 @@ public class EntitlementCache(
         }
     }
 
-    private val _state = MutableStateFlow<EntitlementState>(EntitlementState.Revoked)
+    private val _state = MutableStateFlow<Map<K, EntitlementState>>(emptyMap())
 
     /**
-     * The current entitlement state. `Revoked` until [start] hydrates from
-     * storage and the first event arrives.
+     * The current entitlement state per key. Keys absent from the map are
+     * implicitly [EntitlementState.Revoked] (the cache hasn't observed a
+     * granting purchase for them). Empty until [start] hydrates from storage
+     * and the first event arrives.
      */
-    public val state: StateFlow<EntitlementState> = _state.asStateFlow()
+    public val state: StateFlow<Map<K, EntitlementState>> = _state.asStateFlow()
 
-    // Most-recent confirmed snapshot. Tracked separately from `_state` so
-    // grace transitions can preserve the underlying confirmed observation
+    /**
+     * Convenience: a [Flow] over one specific key's [EntitlementState],
+     * de-duped against unchanged values. An absent key surfaces as
+     * [EntitlementState.Revoked].
+     */
+    public fun stateFor(key: K): Flow<EntitlementState> =
+        state.map { it[key] ?: EntitlementState.Revoked }.distinctUntilChanged()
+
+    // Most-recent confirmed snapshot per key. Tracked separately from `_state`
+    // so grace transitions can preserve the underlying confirmed observation
     // (purchaseToken, confirmedAtMs) without re-querying storage, and so the
     // grace window can be anchored to confirmedAtMs instead of clock() (which
     // would let repeated Failures keep extending grace indefinitely).
-    private var lastConfirmedSnapshot: EntitlementSnapshot? = null
+    // Mutated only under [mutex].
+    private val lastConfirmedSnapshots: MutableMap<K, EntitlementSnapshot> = HashMap()
 
     // Guards reduce() so concurrent emissions (the upstream flow + the
-    // grace tick) can't race on _state / lastConfirmedSnapshot updates.
+    // grace tick) can't race on _state / lastConfirmedSnapshots updates.
     private val mutex = Mutex()
 
-    // The active collection Job from the most recent successful start(),
-    // or null if the cache hasn't been started yet (or a prior start was
-    // cancelled mid-hydration). Guarded by [mutex] so concurrent start()
-    // callers serialise — the second caller blocks until the first has
-    // either established a Job (returns the same handle) or failed
-    // (re-attempts hydration + launch).
+    // The active collection Job from the most recent successful start(), or
+    // null if the cache hasn't been started yet (or a prior start was cancelled
+    // mid-hydration). Guarded by [mutex] so concurrent start() callers
+    // serialise.
     private var collectionJob: Job? = null
 
-    // CONFLATED channel that decouples persistence from state mutation.
-    // Producers (reduce + tickGraceWindow) call writeChannel.trySend(snapshot)
-    // while holding [mutex] so trySend order matches state-mutation order
-    // across coroutines. A single writer coroutine (launched inside [start])
-    // consumes the channel and calls [storage.write] serially.
+    // UNLIMITED so per-key conflation isn't lost across coroutines (CONFLATED
+    // would let a later snapshot for key A clobber an in-flight snapshot for
+    // key B). Producers (reduce + tickGraceWindow) call
+    // `writeChannel.trySend(key to snapshot)` while holding [mutex] so trySend
+    // order matches state-mutation order across coroutines. A single writer
+    // coroutine (launched inside [start]) consumes the channel and calls
+    // [storage.write] serially.
     //
-    // Why CONFLATED: only the most-recent in-memory state needs to land on
-    // disk — older queued snapshots are stale by definition. If reduce
-    // mutates A → B → C in rapid succession while a slow consumer storage
-    // is mid-write, the channel keeps just C; the writer drains the buffer
-    // in send order (A, then C — A from the in-flight write that started
-    // before conflation, C from the conflated tail) and disk ends at C.
-    //
-    // This solves two concerns simultaneously: a slow consumer storage
-    // can't stall reduce/tick (writes happen on the dedicated writer
-    // coroutine, not inline), AND writes land in state-mutation order
-    // (channel preserves send order; senders hold the state mutex so
-    // their send order matches their mutation order).
-    private val writeChannel = Channel<EntitlementSnapshot>(Channel.CONFLATED)
+    // Entitlement transitions happen at human pace (PBL events, periodic
+    // grace ticks throttled by graceTickIntervalMs) — unbounded buffer growth
+    // is theoretical, with at most a handful of entries per session.
+    private val writeChannel = Channel<Pair<K, EntitlementSnapshot>>(Channel.UNLIMITED)
 
     /**
      * Hydrates from [storage] and begins collecting from [purchasesUpdates] +
      * ticking the grace clock inside [scope]. Suspends until hydration
-     * completes, so by the time [start] returns, `state.value` already
-     * reflects the persisted snapshot — callers that read `state` immediately
-     * after `start()` returns will see the hydrated value, not the default
-     * `Revoked`. A failed read is treated as "no prior snapshot" and logged
-     * via [logger]; the cache proceeds with the default `Revoked` state.
+     * completes, so by the time [start] returns, [state] already reflects the
+     * persisted snapshots — callers that read [state] immediately after
+     * `start()` returns will see the hydrated map, not the default empty
+     * map. A failed read is treated as "no prior snapshots" and logged via
+     * [logger]; the cache proceeds with the empty initial state.
      *
      * Returns the parent [Job] orchestrating the upstream collector and the
      * grace tick. Cancel the returned job (or the [scope] itself) to stop
@@ -263,58 +321,57 @@ public class EntitlementCache(
      */
     @AnyThread
     public suspend fun start(scope: CoroutineScope): Job = mutex.withLock {
-        // If a previous start() succeeded and that Job is still active,
-        // hand back the same handle — multiple callers cancelling the same
-        // Job is idempotent, and we don't want N collectors racing on
+        // If a previous start() succeeded and that Job is still active, hand
+        // back the same handle — multiple callers cancelling the same Job is
+        // idempotent, and we don't want N collectors racing on
         // purchasesUpdates + N tick coroutines fighting over storage.
         collectionJob?.let { if (it.isActive) return@withLock it }
 
-        // Drain any snapshot left buffered from a prior cancelled start().
-        // CONFLATED holds at most one element, so this loop runs at most
-        // once. Without this, a snapshot queued just before the previous
-        // start()'s scope was cancelled would be picked up by the NEW
-        // writer coroutine and persisted *after* hydration, overwriting
-        // storage with a stale state and creating a state/storage
-        // mismatch for the rest of the process.
+        // Drain any per-key snapshots left buffered from a prior cancelled
+        // start(). UNLIMITED can hold more than one entry, so this loop runs
+        // until empty. Without it, snapshots queued just before the previous
+        // start()'s scope was cancelled would be picked up by the NEW writer
+        // coroutine and persisted *after* hydration, overwriting storage
+        // with stale state.
         while (writeChannel.tryReceive().isSuccess) { /* discard */ }
 
-        // Hydrate from storage. Done inside the mutex so a second caller
-        // can't observe state.value before the first caller's hydration
-        // lands — the second caller blocks here until the first has
-        // either established a Job or failed (in which case the second
-        // caller retries hydration). Putting it inside the mutex also
-        // means events emitted on purchasesUpdates DURING hydration are
-        // processed against a fully-hydrated state (reduce() takes the
-        // same mutex).
-        val initial = try {
-            storage.read()
+        // Hydrate from storage. Done inside the mutex so a second caller can't
+        // observe state.value before the first caller's hydration lands — the
+        // second caller blocks here until the first has either established a
+        // Job or failed (in which case the second caller retries hydration).
+        // Putting it inside the mutex also means events emitted on
+        // purchasesUpdates DURING hydration are processed against a
+        // fully-hydrated state (reduce() takes the same mutex).
+        val initial: Map<K, EntitlementSnapshot> = try {
+            storage.readAll()
         } catch (ce: CancellationException) {
             // Re-throw cancellation so structured concurrency works.
             // collectionJob remains null; a future start() retries.
             throw ce
         } catch (e: Throwable) {
-            logger.e("EntitlementCache: failed to read snapshot from storage; proceeding with default Revoked state", e)
-            null
+            logger.e(
+                "EntitlementCache: failed to read snapshots from storage; proceeding with empty initial state",
+                e,
+            )
+            emptyMap()
         }
-        if (initial != null) {
-            lastConfirmedSnapshot = initial
-            _state.value = if (initial.isEntitled) {
-                EntitlementState.Granted
-            } else {
-                EntitlementState.Revoked
+        lastConfirmedSnapshots.clear()
+        if (initial.isNotEmpty()) {
+            lastConfirmedSnapshots.putAll(initial)
+            _state.value = initial.mapValues { (_, snap) ->
+                if (snap.isEntitled) EntitlementState.Granted else EntitlementState.Revoked
             }
+        } else {
+            _state.value = emptyMap()
         }
 
         // Periodic tick detects grace expiry without a fresh upstream event.
         // Single-writer coroutine consumes [writeChannel] in send order so
         // persistence is serialised AND a slow consumer storage can't stall
-        // reduce/tick (those just trySend to the channel). Wrapped in
-        // supervisorScope so a tick failure (defensive — tick is
-        // straightforward but errors in user-supplied storage on a tick-driven
-        // grace transition could surface here) doesn't cancel the upstream
-        // collector. Tick + writer lifecycles are bound to the upstream
-        // collect: if purchasesUpdates ever completes normally, we cancel
-        // both children so this start() Job can finish too.
+        // reduce/tick. Wrapped in supervisorScope so a tick failure doesn't
+        // cancel the upstream collector. Tick + writer lifecycles are bound
+        // to the upstream collect: if purchasesUpdates ever completes
+        // normally, we cancel both children so this start() Job can finish.
         val job = scope.launch {
             supervisorScope {
                 val tickJob = launch { tickGraceWindow() }
@@ -335,24 +392,32 @@ public class EntitlementCache(
 
     /**
      * Writer coroutine: drains [writeChannel] in FIFO order and serially
-     * calls [storage.write] on each snapshot. Failures are logged + absorbed
-     * (per the "unwritable storage shouldn't crash the cache" policy);
-     * CancellationException propagates so structured concurrency works.
+     * calls [storage.write] on each (key, snapshot) pair. Failures are logged
+     * + absorbed (per the "unwritable storage shouldn't crash the cache"
+     * policy); CancellationException propagates so structured concurrency
+     * works.
      */
     private suspend fun runStorageWriter() {
-        for (snapshot in writeChannel) {
+        for ((key, snapshot) in writeChannel) {
             try {
-                storage.write(snapshot)
+                storage.write(key, snapshot)
             } catch (ce: CancellationException) {
                 throw ce
             } catch (e: Throwable) {
                 if (snapshot.isEntitled) {
-                    logger.e("EntitlementCache: failed to write Granted snapshot to storage", e)
+                    logger.e(
+                        "EntitlementCache: failed to write Granted snapshot to storage for key=$key",
+                        e,
+                    )
                 } else {
                     // Failure to persist Revoked is more serious than failure
-                    // to persist Granted — the next process start could hydrate
-                    // as Granted from the stale snapshot.
-                    logger.e("EntitlementCache: failed to write Revoked snapshot to storage; next process start may hydrate as Granted from stale snapshot", e)
+                    // to persist Granted — the next process start could
+                    // hydrate as Granted from the stale snapshot.
+                    logger.e(
+                        "EntitlementCache: failed to write Revoked snapshot to storage for key=$key; " +
+                            "next process start may hydrate as Granted from stale snapshot",
+                        e,
+                    )
                 }
             }
         }
@@ -362,14 +427,18 @@ public class EntitlementCache(
         while (true) {
             delay(graceTickIntervalMs)
             mutex.withLock {
-                val current = _state.value
-                if (current is EntitlementState.InGrace && clock() >= current.expiresAtMs) {
-                    val snapshot = transitionToRevoked()
+                val now = clock()
+                // Snapshot the map of expired keys before mutating; iterating
+                // the live _state.value while transitionToRevoked rewrites it
+                // would mutate-while-iterating.
+                val expired = _state.value.filter { (_, s) ->
+                    s is EntitlementState.InGrace && now >= s.expiresAtMs
+                }.keys.toList()
+                for (key in expired) {
                     // trySend inside the mutex so the channel's FIFO order
                     // matches state-mutation order across reduce + tick.
-                    // CONFLATED + UNLIMITED-buffer semantic: trySend never
-                    // suspends and never fails.
-                    writeChannel.trySend(snapshot)
+                    // UNLIMITED: trySend never suspends and never fails.
+                    writeChannel.trySend(key to transitionToRevoked(key))
                 }
             }
         }
@@ -377,21 +446,26 @@ public class EntitlementCache(
 
     // Visible for tests + the start() collector. Synchronised on `mutex` so
     // concurrent emissions (upstream collector + tick) serialise on state
-    // updates. Storage writes are queued via [writeChannel] (CONFLATED) and
+    // updates. Storage writes are queued via [writeChannel] (UNLIMITED) and
     // drained by [runStorageWriter]; a slow consumer EntitlementStorage
     // (DataStore, encrypted prefs, etc.) can't stall the upstream collector
     // or the grace tick because trySend never suspends. Sending inside the
     // mutex preserves write order across reduce + tick.
     internal suspend fun reduce(event: PurchaseEvent) {
         mutex.withLock {
-            // Re-evaluate grace expiry on every emission so an outage longer
-            // than the policy correctly transitions InGrace → Revoked even
-            // before we've classified the new event.
-            val current = _state.value
-            if (current is EntitlementState.InGrace && clock() >= current.expiresAtMs) {
-                writeChannel.trySend(transitionToRevoked())
+            // Pre-pass: re-evaluate grace expiry across all keys on every
+            // emission so an outage longer than the policy correctly
+            // transitions InGrace → Revoked even before we've classified the
+            // new event.
+            val now = clock()
+            val expired = _state.value.filter { (_, s) ->
+                s is EntitlementState.InGrace && now >= s.expiresAtMs
+            }.keys.toList()
+            for (key in expired) {
+                writeChannel.trySend(key to transitionToRevoked(key))
             }
-            val eventSnapshot: EntitlementSnapshot? = when (event) {
+
+            val toPersist: List<Pair<K, EntitlementSnapshot>> = when (event) {
                 is OwnedPurchases.Live -> handleObservation(event.purchases)
                 is OwnedPurchases.Recovered -> handleObservation(event.purchases)
                 is FlowOutcome.Failure -> handleFailure(event.exception)
@@ -406,148 +480,160 @@ public class EntitlementCache(
                     // owned-purchase signal that should mutate cache state.
                     // UnknownResponse is reserved for codes PBL doesn't
                     // document — log/observe at the consumer layer if needed.
-                    null
+                    emptyList()
                 }
             }
-            eventSnapshot?.let { writeChannel.trySend(it) }
+            for ((key, snapshot) in toPersist) {
+                writeChannel.trySend(key to snapshot)
+            }
         }
-    }
-
-    /** Returns the snapshot to persist, or null if no transition produced one. */
-    private fun handleObservation(purchases: List<Purchase>): EntitlementSnapshot? {
-        // Filter to PURCHASED state before applying productPredicate. PBL's OK
-        // callback (which the listener routes to OwnedPurchases.Live) can
-        // include rare UNSPECIFIED_STATE entries; granting entitlement on those
-        // would be premature — entitlement belongs to actually-purchased state.
-        // Pending purchases are a separate event (FlowOutcome.Pending) and
-        // never reach this code path.
-        val match = purchases
-            .firstOrNull { it.purchaseState == Purchase.PurchaseState.PURCHASED && productPredicate(it) }
-            ?: return null
-        // No-match cases (both Live and Recovered) intentionally do NOT
-        // revoke. Live can carry UNSPECIFIED_STATE entries or products
-        // unrelated to this cache's productPredicate, and Recovered
-        // only emits the PURCHASED && !isAcknowledged subset of owned
-        // purchases (filtered against the library's acknowledgedTokens set
-        // per the dedupe in BillingClientStorage). Treating either as
-        // authoritative for revocation would falsely revoke users whose
-        // entitling purchase has already been acknowledged: it never
-        // appears in Recovered, so the predicate never matches, and an
-        // empty Recovered would clobber a valid Granted state.
-        //
-        // Revocation in this cache flows through two narrow paths instead:
-        //  - [PurchaseRevoked] — the consumer pushes an explicit
-        //    revocation signal via emitExternalRevocation (typically
-        //    decoded from RTDN→FCM payloads).
-        //  - Grace-window expiry on persistent [FlowOutcome.Failure].
-        // Recovered is grant-only here: it surfaces unacked purchases for
-        // entitlement confirmation and does NOT speak to the revoke side.
-        val snapshot = EntitlementSnapshot(
-            isEntitled = true,
-            confirmedAtMs = clock(),
-            purchaseToken = match.purchaseToken,
-        )
-        return transitionToGranted(snapshot)
-    }
-
-    /** Returns the snapshot to persist, or null if the revocation didn't match the cached purchase. */
-    private fun handleRevoked(event: PurchaseRevoked): EntitlementSnapshot? {
-        // Match the revocation against the cached snapshot's purchaseToken.
-        // If it matches, the purchase that established our entitlement has
-        // been revoked Play-side — transition to Revoked unconditionally
-        // (no grace; Play has explicitly revoked). If it doesn't match,
-        // the revocation is for a different purchase the consumer is
-        // tracking and this cache's state is unaffected.
-        val confirmed = lastConfirmedSnapshot
-        if (confirmed != null && confirmed.purchaseToken == event.purchaseToken) {
-            val revokedSnapshot = EntitlementSnapshot(
-                isEntitled = false,
-                confirmedAtMs = clock(),
-                purchaseToken = event.purchaseToken,
-            )
-            return transitionToRevoked(revokedSnapshot)
-        }
-        return null
-    }
-
-    /** Returns the snapshot to persist, or null if no persist is needed (no-op or InGrace transition). */
-    private fun handleFailure(exception: BillingException): EntitlementSnapshot? {
-        val current = _state.value
-        // Failures only move us to InGrace if we were previously confirmed
-        // entitled. A Failure while already Revoked stays Revoked — there's
-        // nothing to extend grace for.
-        if (current !is EntitlementState.Granted && current !is EntitlementState.InGrace) {
-            return null
-        }
-
-        val reason = exception.toGraceReason()
-        val window = gracePolicy.windowMsFor(reason)
-        if (window == 0L) {
-            // Grace disabled for this reason — transition straight to Revoked.
-            return transitionToRevoked()
-        }
-
-        // Anchor grace expiry to the last confirmed observation, not clock().
-        // Using clock() would let repeated Failures keep extending the grace
-        // window indefinitely — every new failure would push expiresAt
-        // forward by `window`, defeating the bounded-grace guarantee. With
-        // confirmedAtMs anchoring, multiple Failures arriving over time all
-        // produce the same expiresAt (assuming reason is stable), and a
-        // Failure long after the last confirmation correctly produces an
-        // already-expired window that immediately transitions to Revoked.
-        //
-        // lastConfirmedSnapshot is non-null at this point: the early return
-        // above only allows entry from Granted or InGrace, both of which
-        // imply we've previously transitioned to Granted (which sets the
-        // snapshot).
-        val confirmedAt = lastConfirmedSnapshot?.confirmedAtMs ?: clock()
-        val expiresAt = confirmedAt + window
-        if (clock() >= expiresAt) {
-            // Window has already elapsed since the last confirmation — skip
-            // InGrace entirely and revoke now.
-            return transitionToRevoked()
-        }
-        _state.value = EntitlementState.InGrace(
-            expiresAtMs = expiresAt,
-            reason = reason,
-        )
-        // Intentionally do NOT persist InGrace. The expiry derives from the
-        // already-persisted confirmedAtMs + the policy window; persisting the
-        // grace state itself would risk storage tampering reseting the
-        // window.
-        return null
     }
 
     /**
-     * State-only Granted transition; returns the snapshot to persist (caller
-     * does the storage.write outside the mutex).
+     * Maps PURCHASED-state purchases through [productKeySelector] and
+     * transitions each matching key to Granted. Multiple purchases in one
+     * event mapping to the same key (rare — Play doesn't issue duplicates,
+     * but multi-quantity replays or odd test fixtures could) collapse to the
+     * first match's snapshot; subsequent matches for the same key are
+     * skipped.
+     *
+     * Consumables: this method confirms entitlement for the *key* the
+     * consumable purchase selector returns — which is typically `null` for
+     * consumables, because a consumable purchase is a wallet credit, not an
+     * entitlement. See the
+     * [Consumables ledger guide](https://kanetik.github.io/billing-library/guides/consumables/)
+     * for the recommended wallet-on-the-side pattern.
      */
-    private fun transitionToGranted(snapshot: EntitlementSnapshot): EntitlementSnapshot {
-        lastConfirmedSnapshot = snapshot
-        _state.value = EntitlementState.Granted
+    private fun handleObservation(purchases: List<Purchase>): List<Pair<K, EntitlementSnapshot>> {
+        // Filter to PURCHASED state before applying productKeySelector. PBL's
+        // OK callback (which the listener routes to OwnedPurchases.Live) can
+        // include rare UNSPECIFIED_STATE entries; granting entitlement on
+        // those would be premature — entitlement belongs to actually-purchased
+        // state. Pending purchases are a separate event (FlowOutcome.Pending)
+        // and never reach this code path.
+        //
+        // No-match cases (both Live and Recovered) intentionally do NOT
+        // revoke. Live can carry UNSPECIFIED_STATE entries or products
+        // unrelated to any tracked entitlement, and Recovered only emits the
+        // PURCHASED && !isAcknowledged subset of owned purchases (filtered
+        // against the library's acknowledgedTokens set per the dedupe in
+        // BillingClientStorage). Treating either as authoritative for
+        // revocation would falsely revoke users whose entitling purchase has
+        // already been acknowledged.
+        //
+        // Revocation in this cache flows through two narrow paths instead:
+        //  - [PurchaseRevoked] — the consumer pushes an explicit revocation
+        //    signal via emitExternalRevocation (typically decoded from
+        //    RTDN→FCM payloads).
+        //  - Grace-window expiry on persistent [FlowOutcome.Failure].
+        val now = clock()
+        val results = ArrayList<Pair<K, EntitlementSnapshot>>()
+        val seen = HashSet<K>()
+        for (purchase in purchases) {
+            if (purchase.purchaseState != Purchase.PurchaseState.PURCHASED) continue
+            val key = productKeySelector(purchase) ?: continue
+            if (!seen.add(key)) continue
+            val snapshot = EntitlementSnapshot(
+                isEntitled = true,
+                confirmedAtMs = now,
+                purchaseToken = purchase.purchaseToken,
+            )
+            results.add(key to transitionToGranted(key, snapshot))
+        }
+        return results
+    }
+
+    /**
+     * Matches the revoked `purchaseToken` against every cached snapshot. At
+     * most one key will match (Play guarantees tokens are unique per purchase).
+     * If a match is found, that key transitions to Revoked immediately (no
+     * grace — Play has explicitly revoked).
+     */
+    private fun handleRevoked(event: PurchaseRevoked): List<Pair<K, EntitlementSnapshot>> {
+        val now = clock()
+        val results = ArrayList<Pair<K, EntitlementSnapshot>>()
+        for ((key, confirmed) in lastConfirmedSnapshots) {
+            if (confirmed.purchaseToken == event.purchaseToken) {
+                val snapshot = EntitlementSnapshot(
+                    isEntitled = false,
+                    confirmedAtMs = now,
+                    purchaseToken = event.purchaseToken,
+                )
+                results.add(key to transitionToRevoked(key, snapshot))
+            }
+        }
+        return results
+    }
+
+    /**
+     * Applies the grace policy to every currently-Granted or InGrace key.
+     * Each key's grace window is anchored to *its own* lastConfirmedSnapshot's
+     * confirmedAtMs, not to the failure's arrival time — repeated Failures
+     * across multiple keys all produce the same expiresAt for each (assuming
+     * reason is stable). A Failure long after a key's last confirmation
+     * correctly produces an already-expired window and immediately revokes
+     * that key.
+     */
+    private fun handleFailure(exception: BillingException): List<Pair<K, EntitlementSnapshot>> {
+        val reason = exception.toGraceReason()
+        val window = gracePolicy.windowMsFor(reason)
+        val now = clock()
+        val results = ArrayList<Pair<K, EntitlementSnapshot>>()
+        val candidates = _state.value.filter {
+            it.value is EntitlementState.Granted || it.value is EntitlementState.InGrace
+        }.keys.toList()
+        for (key in candidates) {
+            if (window == 0L) {
+                // Grace disabled for this reason — straight to Revoked.
+                results.add(key to transitionToRevoked(key))
+                continue
+            }
+            val confirmedAt = lastConfirmedSnapshots[key]?.confirmedAtMs ?: now
+            val expiresAt = confirmedAt + window
+            if (now >= expiresAt) {
+                results.add(key to transitionToRevoked(key))
+            } else {
+                // Intentionally do NOT persist InGrace. The expiry derives
+                // from the already-persisted confirmedAtMs + the policy
+                // window; persisting the grace state itself would risk
+                // storage tampering resetting the window.
+                _state.value = _state.value + (key to EntitlementState.InGrace(expiresAt, reason))
+            }
+        }
+        return results
+    }
+
+    /**
+     * State-only Granted transition for [key]; returns the snapshot to
+     * persist (the caller queues the write).
+     */
+    private fun transitionToGranted(key: K, snapshot: EntitlementSnapshot): EntitlementSnapshot {
+        lastConfirmedSnapshots[key] = snapshot
+        _state.value = _state.value + (key to EntitlementState.Granted)
         return snapshot
     }
 
     /**
-     * State-only Revoked transition; returns the snapshot to persist (caller
-     * does the storage.write outside the mutex). Always returns a Revoked
+     * State-only Revoked transition for [key]; returns the snapshot to
+     * persist (the caller queues the write). Always returns a Revoked
      * snapshot — without persisting, grace-expiry paths would leave storage
      * holding the last Granted state, and the next process start would
      * hydrate as Granted incorrectly. If no fresh snapshot is supplied
      * (typical for grace-expiry transitions), builds one from
-     * lastConfirmedSnapshot's purchaseToken so the persisted record still
-     * ties back to the purchase that just expired its grace.
+     * lastConfirmedSnapshots[key]'s purchaseToken so the persisted record
+     * still ties back to the purchase that just expired its grace.
      */
-    private fun transitionToRevoked(snapshot: EntitlementSnapshot? = null): EntitlementSnapshot {
+    private fun transitionToRevoked(key: K, snapshot: EntitlementSnapshot? = null): EntitlementSnapshot {
         val toPersist = snapshot ?: EntitlementSnapshot(
             isEntitled = false,
             confirmedAtMs = clock(),
-            purchaseToken = lastConfirmedSnapshot?.purchaseToken,
+            purchaseToken = lastConfirmedSnapshots[key]?.purchaseToken,
         )
-        lastConfirmedSnapshot = toPersist
+        lastConfirmedSnapshots[key] = toPersist
         // Set _state immediately so the UI sees Revoked even with slow
-        // storage. Persistence happens outside the mutex via the caller.
-        _state.value = EntitlementState.Revoked
+        // storage. Persistence happens via the caller queueing onto the
+        // write channel.
+        _state.value = _state.value + (key to EntitlementState.Revoked)
         return toPersist
     }
 
@@ -566,7 +652,7 @@ public class EntitlementCache(
  * Maps a [BillingException] to the matching [GraceReason].
  *
  * Uses [BillingException.userFacingCategory] as the discriminator since that
- * already collapses the 13 typed subtypes into the same buckets we want here:
+ * already collapses the typed subtypes into the same buckets we want here:
  *
  *  - [BillingErrorCategory.BillingUnavailable] → [GraceReason.BillingUnavailable].
  *  - Everything else → [GraceReason.TransientFailure]. The default is the

--- a/billing/src/main/kotlin/com/kanetik/billing/entitlement/EntitlementState.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/entitlement/EntitlementState.kt
@@ -1,21 +1,23 @@
 package com.kanetik.billing.entitlement
 
 /**
- * The cached entitlement state surfaced by [EntitlementCache].
+ * The cached entitlement state for a single key, surfaced by
+ * [EntitlementCache] via its `state: StateFlow<Map<K, EntitlementState>>`
+ * (and the per-key [EntitlementCache.stateFor] convenience).
  *
  * Three terminal states cover the full lifecycle of an "is the user entitled
- * to premium right now?" question:
+ * to this thing right now?" question:
  *
  *  - [Granted] — the cache has confirmed the user owns a matching purchase.
- *    Show premium UI.
+ *    Show the gated UI / unlock the feature / etc.
  *  - [InGrace] — the cache recently saw entitlement, then hit a transient
  *    failure (network outage, billing service unavailable, etc.) before it
- *    could re-confirm. The user is still treated as entitled until
+ *    could re-confirm. The key is still treated as entitled until
  *    [InGrace.expiresAtMs] passes; after that the cache transitions to
- *    [Revoked]. Lets premium features keep working through a brief outage
+ *    [Revoked]. Lets gated features keep working through a brief outage
  *    instead of yanking them out from under a paid user.
- *  - [Revoked] — the cache has either never seen entitlement, or grace has
- *    expired without a successful re-check. Hide premium UI.
+ *  - [Revoked] — the cache has either never seen entitlement for this key,
+ *    or grace has expired without a successful re-check. Hide the gated UI.
  *
  * Branch on the sealed type to render UI rather than comparing instances by
  * equality. The [InGrace.expiresAtMs] timestamp is set once when the
@@ -28,11 +30,12 @@ package com.kanetik.billing.entitlement
 public sealed interface EntitlementState {
 
     /**
-     * The user owns a matching purchase. Show premium UI.
+     * The user owns a matching purchase for this key. Show the gated UI /
+     * unlock the corresponding feature.
      *
      * Reached on:
      *  - A [com.kanetik.billing.OwnedPurchases.Live] containing a purchase
-     *    matching the cache's `productPredicate`.
+     *    that this cache's `productKeySelector` maps to this key.
      *  - A [com.kanetik.billing.OwnedPurchases.Recovered] containing a
      *    matching purchase (the recovery sweep on connect).
      *  - A persisted [EntitlementSnapshot] read at start with `isEntitled = true`.
@@ -42,7 +45,7 @@ public sealed interface EntitlementState {
     /**
      * Entitlement was recently confirmed but a subsequent
      * [com.kanetik.billing.FlowOutcome.Failure] prevented re-confirmation.
-     * Treat the user as entitled until [expiresAtMs]; after that the cache
+     * Treat the key as entitled until [expiresAtMs]; after that the cache
      * transitions to [Revoked].
      *
      * @property expiresAtMs Wall-clock time (in `System.currentTimeMillis()`
@@ -57,17 +60,17 @@ public sealed interface EntitlementState {
     ) : EntitlementState
 
     /**
-     * No entitlement. Hide premium UI.
+     * No entitlement for this key. Hide the gated UI.
      *
      * Reached on:
      *  - A [com.kanetik.billing.PurchaseRevoked] event whose `purchaseToken`
-     *    matches the cached snapshot's last confirmed purchase. The consumer
-     *    pushes these via `emitExternalRevocation` from their RTDN→FCM (or
-     *    polling, or deeplink) pipeline.
+     *    matches the cached snapshot's last confirmed purchase for this key.
+     *    The consumer pushes these via `emitExternalRevocation` from their
+     *    RTDN→FCM (or polling, or deeplink) pipeline.
      *  - An [InGrace] state whose [InGrace.expiresAtMs] has elapsed without
      *    a fresh `Granted` confirmation.
-     *  - The default state when no prior snapshot exists and nothing has
-     *    arrived yet.
+     *  - The implicit default for any key absent from the state map (no
+     *    prior snapshot, nothing has arrived yet).
      *
      * Notably **not** reached on a non-matching `OwnedPurchases.Recovered`
      * (or `Live`) event. Recovered only emits the unacknowledged subset of

--- a/billing/src/main/kotlin/com/kanetik/billing/entitlement/EntitlementStorage.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/entitlement/EntitlementStorage.kt
@@ -22,8 +22,17 @@ package com.kanetik.billing.entitlement
  * identifier. For `String` keys that's the identity; for `enum class` keys
  * use `K.name` (the constant identifier, not `toString()` — `toString()` can
  * be overridden); for sealed classes pick a stable discriminator field.
- * Stability across app upgrades matters — renaming an enum constant breaks
- * the on-disk mapping.
+ *
+ * Two requirements on the serialization:
+ *
+ *  - **Injective.** Two distinct `K` values must never serialize to the same
+ *    on-disk identifier. Collisions cause snapshot overwrites and (when paired
+ *    with [com.kanetik.billing.entitlement.signed.SignedEntitlementStorage])
+ *    cross-key signature collisions / spurious tamper events. The library
+ *    does not validate this defensively; it's a caller contract.
+ *  - **Stable across app upgrades.** Renaming an enum constant breaks the
+ *    on-disk mapping for that entitlement and surfaces as the snapshot
+ *    appearing to vanish (re-confirmed on the next live purchase event).
  *
  * ## Contract
  *

--- a/billing/src/main/kotlin/com/kanetik/billing/entitlement/EntitlementStorage.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/entitlement/EntitlementStorage.kt
@@ -8,45 +8,62 @@ package com.kanetik.billing.entitlement
  * Room, signed prefs against a server-issued key, etc.). Implement this
  * interface against whatever you already use.
  *
+ * ## Generic on K
+ *
+ * The storage holds **one snapshot per entitlement key**. `K` is whatever
+ * type your app uses to discriminate entitlements — a `String` product ID, a
+ * sealed class of grants, an `enum`, `Unit` for a single-entitlement app, etc.
+ * The cache's `productKeySelector` maps each observed [com.android.billingclient.api.Purchase]
+ * to a `K?` (null = doesn't grant any tracked entitlement); the cache holds
+ * one [EntitlementState] per key in its [EntitlementCache.state] map; this
+ * interface writes / reads one [EntitlementSnapshot] per key.
+ *
+ * Your implementation is responsible for serializing `K` to a stable on-disk
+ * identifier. For `String` keys that's the identity; for `enum class` keys
+ * use `K.name` (the constant identifier, not `toString()` — `toString()` can
+ * be overridden); for sealed classes pick a stable discriminator field.
+ * Stability across app upgrades matters — renaming an enum constant breaks
+ * the on-disk mapping.
+ *
  * ## Contract
  *
- *  - [read] is called once at [EntitlementCache.start] time. Returning
- *    `null` means "no prior state" — the cache starts in
- *    [EntitlementState.Revoked].
- *  - [write] is called on every entitlement-affecting transition (Granted →
- *    snapshot with `isEntitled = true`; Revoked → snapshot with
- *    `isEntitled = false`). [EntitlementState.InGrace] is **not**
- *    persisted; grace re-derives from the most recent confirmed
+ *  - [readAll] is called once at [EntitlementCache.start] time. Returning an
+ *    empty map means "no prior state" — the cache starts with every entitlement
+ *    in [EntitlementState.Revoked].
+ *  - [write] is called on every entitlement-affecting transition. Each call
+ *    carries one `(K, EntitlementSnapshot)` pair; implementations should treat
+ *    it as an upsert. Granted transitions write `isEntitled = true`; Revoked
+ *    transitions write `isEntitled = false`. [EntitlementState.InGrace] is
+ *    **not** persisted; grace re-derives from the most recent confirmed
  *    `confirmedAtMs` on read.
  *  - Both methods are `suspend` so backing implementations can do disk I/O
  *    without blocking. Note the dispatch contexts differ:
- *      - [read] is invoked by `EntitlementCache.start()` in the **caller's**
+ *      - [readAll] is invoked by `EntitlementCache.start()` in the **caller's**
  *        coroutine context (typically the same scope the caller passes to
  *        `start()`). If your `start()` is launched on `Dispatchers.Main`
  *        (e.g., `viewModelScope.launch { cache.start(viewModelScope) }`),
- *        `read()` runs on Main unless your implementation switches.
+ *        `readAll()` runs on Main unless your implementation switches.
  *      - [write] is invoked by an internal writer coroutine launched into
- *        the scope supplied to `start()`, draining a CONFLATED channel
+ *        the scope supplied to `start()`, draining a CONFLATED-per-key channel
  *        serially.
- *    Your implementation is responsible for any further dispatching it
- *    needs (e.g. wrap the body in `withContext(Dispatchers.IO)` if your
- *    storage isn't already coroutine-friendly). DataStore handles this
- *    transparently; SharedPreferences-backed implementations should
- *    withContext(IO) explicitly.
- *  - [write] should be atomic with respect to [read] — the cache may be
+ *    Your implementation is responsible for any further dispatching it needs
+ *    (e.g. wrap the body in `withContext(Dispatchers.IO)` if your storage
+ *    isn't already coroutine-friendly). DataStore handles this transparently;
+ *    SharedPreferences-backed implementations should withContext(IO) explicitly.
+ *  - [write] should be atomic with respect to [readAll] — the cache may be
  *    re-created between calls (configuration change, process death) and the
- *    next instance's [read] must see the most recent successful [write].
- *    File-based storage with `commit()` semantics, DataStore, or a synced
- *    `Mutex` around in-memory state all qualify.
+ *    next instance's [readAll] must see the most recent successful [write] for
+ *    every key.
  *
  * ## Integrity
  *
  * The [EntitlementSnapshot] type is plain data — no built-in signature or
  * HMAC; the cache trusts what storage returns. If your threat model includes
  * users tampering with on-device storage to extend entitlement (e.g. a
- * freemium app where premium has real value), wrap your implementation in
+ * freemium app where the paid entitlement has real value), wrap your
+ * implementation in
  * [com.kanetik.billing.entitlement.signed.SignedEntitlementStorage] — a
- * decorator that signs the snapshot on write and verifies it on read using
+ * decorator that signs each snapshot on write and verifies it on read using
  * an HMAC key from a [com.kanetik.billing.entitlement.signed.HmacKeyProvider]
  * (recommended default: [com.kanetik.billing.entitlement.signed.KeystoreBackedKeyProvider],
  * which is Android Keystore-backed). The decorator stays neutral on the
@@ -57,17 +74,19 @@ package com.kanetik.billing.entitlement
  * [com.kanetik.billing.OwnedPurchases.Recovered], so a tampered snapshot
  * gets overwritten the next time the user has connectivity.
  */
-public interface EntitlementStorage {
+public interface EntitlementStorage<K : Any> {
 
     /**
-     * @return the most recently persisted snapshot, or `null` if none exists
-     *   (first run, or the snapshot was cleared).
+     * @return every persisted snapshot, keyed by entitlement key. Empty map
+     *   means "no prior state" — the cache starts with every entitlement in
+     *   [EntitlementState.Revoked].
      */
-    public suspend fun read(): EntitlementSnapshot?
+    public suspend fun readAll(): Map<K, EntitlementSnapshot>
 
     /**
-     * Persists [snapshot]. Should be atomic with respect to a subsequent
-     * [read] call; see the interface-level KDoc for the full contract.
+     * Persists [snapshot] under [key]. Upsert semantics: replaces any previous
+     * snapshot for the same key. Should be atomic with respect to a subsequent
+     * [readAll] call; see the interface-level KDoc for the full contract.
      */
-    public suspend fun write(snapshot: EntitlementSnapshot)
+    public suspend fun write(key: K, snapshot: EntitlementSnapshot)
 }

--- a/billing/src/main/kotlin/com/kanetik/billing/entitlement/EntitlementStorage.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/entitlement/EntitlementStorage.kt
@@ -44,8 +44,11 @@ package com.kanetik.billing.entitlement
  *        (e.g., `viewModelScope.launch { cache.start(viewModelScope) }`),
  *        `readAll()` runs on Main unless your implementation switches.
  *      - [write] is invoked by an internal writer coroutine launched into
- *        the scope supplied to `start()`, draining a CONFLATED-per-key channel
- *        serially.
+ *        the scope supplied to `start()`, draining an UNLIMITED `(K, snapshot)`
+ *        channel in send order. Calls are serialised; there is no per-key
+ *        conflation, so back-to-back writes for the same key both reach
+ *        storage. Entitlement transitions happen at human pace (PBL events,
+ *        grace ticks), so the buffer is bounded in practice by activity.
  *    Your implementation is responsible for any further dispatching it needs
  *    (e.g. wrap the body in `withContext(Dispatchers.IO)` if your storage
  *    isn't already coroutine-friendly). DataStore handles this transparently;

--- a/billing/src/main/kotlin/com/kanetik/billing/entitlement/GracePolicy.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/entitlement/GracePolicy.kt
@@ -61,8 +61,8 @@ public data class GracePolicy(
          * Disables grace entirely — every [com.kanetik.billing.FlowOutcome.Failure]
          * transitions a previously-Granted cache straight to
          * [EntitlementState.Revoked]. Use when you'd rather surface the outage
-         * to the user immediately than risk a few extra minutes of premium
-         * during an outage.
+         * to the user immediately than risk a few extra minutes of an
+         * unconfirmed entitlement during an outage.
          */
         public val None: GracePolicy = GracePolicy(
             billingUnavailableMs = 0L,

--- a/billing/src/main/kotlin/com/kanetik/billing/entitlement/GraceReason.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/entitlement/GraceReason.kt
@@ -10,8 +10,8 @@ package com.kanetik.billing.entitlement
  *    device (Play Services missing, account ineligible, region restriction,
  *    feature not supported). These outages are typically longer-lived than
  *    transient network blips, so [GracePolicy] exposes them as a separate
- *    knob — apps may want a longer grace window before yanking premium for
- *    "Play Store isn't working" vs. "user just lost wifi".
+ *    knob — apps may want a longer grace window before yanking a paid
+ *    entitlement for "Play Store isn't working" vs. "user just lost wifi".
  *  - [TransientFailure] — anything else: classification uses the
  *    [com.kanetik.billing.exception.BillingErrorCategory] from
  *    [com.kanetik.billing.exception.BillingException.userFacingCategory],
@@ -19,9 +19,9 @@ package com.kanetik.billing.entitlement
  *    falls into this bucket — including network errors, service
  *    disconnections, generic billing errors, AND terminal failures like
  *    `DeveloperError` or `FatalError`. The cache treats all of those as
- *    "give the user a short grace window before yanking premium"; consumers
- *    that want fatal errors to revoke immediately should pass
- *    [GracePolicy.None] (or set `transientFailureMs = 0`).
+ *    "give the user a short grace window before yanking the paid
+ *    entitlement"; consumers that want fatal errors to revoke immediately
+ *    should pass [GracePolicy.None] (or set `transientFailureMs = 0`).
  */
 public enum class GraceReason {
 

--- a/billing/src/main/kotlin/com/kanetik/billing/entitlement/signed/SharedPreferencesSignatureStore.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/entitlement/signed/SharedPreferencesSignatureStore.kt
@@ -7,13 +7,14 @@ import kotlinx.coroutines.withContext
 import java.io.IOException
 
 /**
- * Default [SignatureStore] that persists the signature blob in a private
+ * Default [SignatureStore] that persists signature blobs in a private
  * SharedPreferences file.
  *
- * Bytes are stored as a base64 string (SharedPreferences doesn't support
- * `byte[]` natively). I/O is wrapped in `withContext(Dispatchers.IO)` so
- * callers can invoke [readSignature] / [writeSignature] from any dispatcher
- * without blocking.
+ * Each entitlement key's blob is stored under prefs key
+ * `"signature:" + entitlementKey`. Bytes are stored as a base64 string
+ * (SharedPreferences doesn't support `byte[]` natively). I/O is wrapped in
+ * `withContext(Dispatchers.IO)` so callers can invoke [readSignature] /
+ * [writeSignature] / [clearSignature] from any dispatcher without blocking.
  *
  * @param context any [Context]; only `applicationContext` is retained.
  * @param fileName SharedPreferences file name. Defaults to a stable
@@ -31,8 +32,8 @@ public class SharedPreferencesSignatureStore(
         appContext.getSharedPreferences(fileName, Context.MODE_PRIVATE)
     }
 
-    override suspend fun readSignature(): ByteArray? = withContext(Dispatchers.IO) {
-        val encoded = prefs.getString(KEY_SIGNATURE, null) ?: return@withContext null
+    override suspend fun readSignature(entitlementKey: String): ByteArray? = withContext(Dispatchers.IO) {
+        val encoded = prefs.getString(prefsKey(entitlementKey), null) ?: return@withContext null
         // A non-decodable string means the prefs file is corrupt or someone
         // tampered with the signature. Return an empty (and therefore
         // shape-invalid) blob so SignedEntitlementStorage's size check fires
@@ -41,7 +42,7 @@ public class SharedPreferencesSignatureStore(
         runCatching { Base64.decode(encoded, Base64.NO_WRAP) }.getOrDefault(ByteArray(0))
     }
 
-    override suspend fun writeSignature(signature: ByteArray) {
+    override suspend fun writeSignature(entitlementKey: String, signature: ByteArray) {
         withContext(Dispatchers.IO) {
             val encoded = Base64.encodeToString(signature, Base64.NO_WRAP)
             // commit() reports false when the synchronous disk write fails
@@ -50,17 +51,28 @@ public class SharedPreferencesSignatureStore(
             // contract — the next read would return a stale blob and verify
             // against a fresh snapshot, surfacing as a false-positive
             // InvalidSignature. Surface the failure instead.
-            val ok = prefs.edit().putString(KEY_SIGNATURE, encoded).commit()
+            val ok = prefs.edit().putString(prefsKey(entitlementKey), encoded).commit()
             if (!ok) {
-                throw IOException("Failed to persist signature to SharedPreferences (file=$fileName)")
+                throw IOException("Failed to persist signature to SharedPreferences (file=$fileName, key=$entitlementKey)")
             }
         }
     }
+
+    override suspend fun clearSignature(entitlementKey: String) {
+        withContext(Dispatchers.IO) {
+            val ok = prefs.edit().remove(prefsKey(entitlementKey)).commit()
+            if (!ok) {
+                throw IOException("Failed to remove signature from SharedPreferences (file=$fileName, key=$entitlementKey)")
+            }
+        }
+    }
+
+    private fun prefsKey(entitlementKey: String): String = PREFS_KEY_PREFIX + entitlementKey
 
     public companion object {
         public const val DEFAULT_FILE_NAME: String =
             "com.kanetik.billing.signed_entitlement.signature"
 
-        private const val KEY_SIGNATURE = "signature"
+        private const val PREFS_KEY_PREFIX = "signature:"
     }
 }

--- a/billing/src/main/kotlin/com/kanetik/billing/entitlement/signed/SignatureStore.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/entitlement/signed/SignatureStore.kt
@@ -1,14 +1,15 @@
 package com.kanetik.billing.entitlement.signed
 
 /**
- * Persistence for the signature blob written alongside an
- * [com.kanetik.billing.entitlement.EntitlementSnapshot].
+ * Persistence for the signature blobs written alongside each
+ * [com.kanetik.billing.entitlement.EntitlementSnapshot] in a multi-entitlement
+ * cache.
  *
- * The blob is small — 4 bytes of version plus 32 bytes of HMAC-SHA256 (~36
- * total). It must outlive process death and survive the same restarts that
- * the snapshot itself does, so that
- * [SignedEntitlementStorage.read] can verify the snapshot returned by the
- * delegate.
+ * Each blob is small — 4 bytes of version plus 32 bytes of HMAC-SHA256 (~36
+ * total) — and there's one per entitlement key. Blobs must outlive process
+ * death and survive the same restarts that the snapshots themselves do, so
+ * that [SignedEntitlementStorage.readAll] can verify each snapshot returned
+ * by the delegate.
  *
  * Default implementation: [SharedPreferencesSignatureStore]. Consumers with
  * existing storage layers (DataStore, encrypted prefs, Room) can implement
@@ -17,24 +18,33 @@ package com.kanetik.billing.entitlement.signed
  *
  * Atomicity expectations match
  * [com.kanetik.billing.entitlement.EntitlementStorage] — a successful
- * [writeSignature] must be visible to the next process's [readSignature].
- * Returning the signature for a *different* snapshot than the delegate
- * returns is fine in steady state (the verification will fail, the read
- * returns null, and the next live confirm restores) but should not be the
- * common case; callers usually pair a single [SignatureStore] with a single
- * delegate so writes interleave consistently.
+ * [writeSignature] for `entitlementKey` must be visible to the next process's
+ * [readSignature] for the same key. The [entitlementKey] is the
+ * already-serialized string identifier produced by
+ * [SignedEntitlementStorage]'s `keyToStorageId` lambda; this interface stays
+ * agnostic to the consumer's `K` type.
  */
 public interface SignatureStore {
 
     /**
-     * Returns the most recently persisted signature blob, or `null` if none
-     * exists (first run, or the blob was cleared).
+     * @return the most recently persisted signature blob for [entitlementKey],
+     *   or `null` if none exists (first run, or the blob was cleared).
      */
-    public suspend fun readSignature(): ByteArray?
+    public suspend fun readSignature(entitlementKey: String): ByteArray?
 
     /**
-     * Persists [signature]. Must be atomic with respect to a subsequent
-     * [readSignature] call.
+     * Persists [signature] under [entitlementKey]. Upsert semantics: replaces
+     * any previous blob for the same key. Must be atomic with respect to a
+     * subsequent [readSignature] call.
      */
-    public suspend fun writeSignature(signature: ByteArray)
+    public suspend fun writeSignature(entitlementKey: String, signature: ByteArray)
+
+    /**
+     * Removes the persisted signature blob for [entitlementKey], if any. The
+     * cache itself doesn't call this; provided so consumers can wipe a
+     * specific entitlement's signature (e.g., a "reset entitlement"
+     * debug/dev affordance) without losing the rest. A subsequent
+     * [readSignature] for the same key returns `null`.
+     */
+    public suspend fun clearSignature(entitlementKey: String)
 }

--- a/billing/src/main/kotlin/com/kanetik/billing/entitlement/signed/SignedEntitlementStorage.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/entitlement/signed/SignedEntitlementStorage.kt
@@ -121,8 +121,13 @@ import java.nio.ByteBuffer
  *   See [SignatureStore].
  * @param keyToStorageId serializes `K` to a stable string identifier. The
  *   string is used both as the lookup key in [signatureStore] and is included
- *   in the v2 canonical bytes. Must be stable across app upgrades (renaming
- *   an enum constant breaks verification of that entitlement's old sigs).
+ *   in the v2 canonical bytes. **Must be injective** — two distinct `K` values
+ *   must never serialize to the same string, or their snapshots / signatures
+ *   collide in storage and verification behaves unpredictably. **Must also be
+ *   stable across app upgrades** — renaming an enum constant breaks
+ *   verification of that entitlement's old sigs. The library does not
+ *   validate collisions defensively; injectivity and stability are caller
+ *   contracts.
  * @param onTamperDetected invoked from [readAll] when verification fails for
  *   a key. Receives the entitlement key (as serialized via [keyToStorageId])
  *   and the typed event. Runs on whatever dispatcher the read is invoked

--- a/billing/src/main/kotlin/com/kanetik/billing/entitlement/signed/SignedEntitlementStorage.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/entitlement/signed/SignedEntitlementStorage.kt
@@ -5,15 +5,29 @@ import com.kanetik.billing.entitlement.EntitlementStorage
 import java.nio.ByteBuffer
 
 /**
- * [EntitlementStorage] decorator that signs the snapshot on write and
+ * [EntitlementStorage] decorator that signs each snapshot on write and
  * verifies the signature on read, providing tamper resistance for the
  * cache's persisted state.
  *
  * Wraps any other [EntitlementStorage] implementation (DataStore, Room,
  * SharedPreferences, etc.). The library remains neutral on the persistence
  * choice; only the signing is centralised. The wrapped [delegate] continues
- * to own the snapshot bytes; the signature blob lives separately in
- * [signatureStore].
+ * to own the snapshot bytes; the signature blob for each entitlement key
+ * lives separately in [signatureStore].
+ *
+ * # Per-key signatures
+ *
+ * Each entitlement key in the cache has its own signature blob. The decorator
+ * uses [keyToStorageId] to serialize `K` to a stable string identifier — that
+ * string is the lookup key in [signatureStore] and is also included in the
+ * canonical bytes that are HMAC'd, so a sig for key A applied to a snapshot
+ * for key B fails verification (cross-key swap detection).
+ *
+ * Pick a stable [keyToStorageId]:
+ *  - `K = String` → `{ it }`
+ *  - `K = SomeEnum` → `{ it.name }` (the constant identifier; `toString()`
+ *    is overridable and not safe)
+ *  - `K = sealed class` → a stable discriminator field
  *
  * # Wire format
  *
@@ -23,42 +37,49 @@ import java.nio.ByteBuffer
  * authenticated and an attacker can't downgrade the version). The per-version
  * snapshot canonical encoding is internal; the wire format is stable and
  * versioned so future field additions to [EntitlementSnapshot] don't
- * invalidate signatures written by older library versions.
+ * invalidate signatures written by older library versions. **v1** signatures
+ * (legacy single-entitlement, no key in canonical bytes) continue to verify
+ * on this build — useful for consumers upgrading from v0.1.x with a single
+ * entitlement (`K = Unit`); their old sigs roundtrip without firing a tamper
+ * event. New writes always use v2.
  *
  * # Read path
  *
- * The decorator returns `null` (the cache reads it as "no prior state") in
- * any of these cases, firing [onTamperDetected] with a typed [TamperEvent]:
+ * The decorator omits a key's snapshot from [readAll] (the cache reads the
+ * absent key as "no prior state for this entitlement") in any of these cases,
+ * firing [onTamperDetected] with a typed [TamperEvent]:
  *
- *  - **[TamperEvent.MissingSignature]** — delegate returned a snapshot but
- *    [signatureStore] is empty. Most likely benign: a one-time read after
- *    upgrading from an unsigned configuration. Route this differently from
- *    [TamperEvent.InvalidSignature] in your telemetry. See
- *    [migrateUnsignedSnapshot] if you want to avoid the cold-start.
+ *  - **[TamperEvent.MissingSignature]** — delegate returned a snapshot for
+ *    the key but [signatureStore] holds no signature for that key. Most
+ *    likely benign: a one-time read after upgrading from an unsigned
+ *    configuration. Route this differently from [TamperEvent.InvalidSignature]
+ *    in your telemetry. See [migrateUnsignedSnapshot] if you want to avoid
+ *    the cold-start.
  *  - **[TamperEvent.InvalidSignature]** — both pieces present, HMAC failed
- *    to verify (or the blob was truncated). Strong tamper indicator; this
- *    is the event your alerting should pay attention to.
+ *    to verify (or the blob was truncated / had trailing bytes). Strong
+ *    tamper indicator; this is the event your alerting should pay attention
+ *    to.
  *  - **[TamperEvent.UnsupportedVersion]** — blob declares a version this
  *    build of the library doesn't know how to verify. Implies forgery, a
  *    forward-incompatible blob written by a newer library version, or
  *    storage corruption.
  *
- * If the delegate returns `null` (no prior snapshot at all), the decorator
- * also returns `null` but does NOT fire [onTamperDetected] — that's the
- * legitimate first-run case.
+ * Verification is per-key: a tamper event on one key drops that key's
+ * snapshot but does not affect the others. The cache still sees verified
+ * snapshots for the unaffected keys.
  *
  * # Write path
  *
- * `write` computes the signature blob first (no side effects), then persists
- * the snapshot via [delegate], then persists the signature via
- * [signatureStore]. Ordering signing first means a [keyProvider] failure
- * (e.g., transient Keystore key generation error) leaves both stores
- * untouched — the next write retries from a consistent state. If the
- * signature write fails *after* the snapshot write succeeded, the next read
- * sees a snapshot/signature mismatch (or no signature on first ever write)
- * and falls back to the cold-start path; the next `OwnedPurchases.Live` or
- * `OwnedPurchases.Recovered` re-confirms truth (often within the same
- * launch, once the billing connection establishes).
+ * [write] computes the signature blob first (no side effects), then persists
+ * the snapshot via [delegate], then persists the signature via [signatureStore].
+ * Ordering signing first means a [keyProvider] failure (e.g., transient
+ * Keystore key generation error) leaves both stores untouched for that key —
+ * the next write retries from a consistent state. If the signature write
+ * fails *after* the snapshot write succeeded, the next read sees a snapshot/
+ * signature mismatch (or no signature on first ever write) and falls back to
+ * the cold-start path for that key; the next `OwnedPurchases.Live` or
+ * `OwnedPurchases.Recovered` re-confirms truth (often within the same launch,
+ * once the billing connection establishes).
  *
  * # Threat-model caveats
  *
@@ -74,123 +95,127 @@ import java.nio.ByteBuffer
  * # Example
  *
  * ```kotlin
- * val storage: EntitlementStorage = SignedEntitlementStorage(
+ * // Multi-entitlement: K is the product ID string.
+ * val storage: EntitlementStorage<String> = SignedEntitlementStorage(
  *     delegate = MyDataStoreEntitlementStorage(context),
  *     keyProvider = KeystoreBackedKeyProvider.create(),
  *     signatureStore = SharedPreferencesSignatureStore(context),
- *     onTamperDetected = { event ->
+ *     keyToStorageId = { it },
+ *     onTamperDetected = { entitlementKey, event ->
  *         when (event) {
- *             TamperEvent.MissingSignature -> logger.info("First read after upgrade")
- *             TamperEvent.InvalidSignature -> logger.warn("Possible tampering detected")
+ *             TamperEvent.MissingSignature -> logger.info("First read for $entitlementKey")
+ *             TamperEvent.InvalidSignature -> logger.warn("Possible tampering on $entitlementKey")
  *             is TamperEvent.UnsupportedVersion ->
- *                 logger.warn("Unknown signature version ${event.version}")
+ *                 logger.warn("Unknown signature version ${event.version} for $entitlementKey")
  *         }
  *     },
  * )
- * val cache = EntitlementCache(purchasesUpdates, storage, gracePolicy, productPredicate)
+ * val cache = EntitlementCache(purchasesUpdates, storage, gracePolicy, productKeySelector)
  * ```
  *
  * @param delegate the underlying [EntitlementStorage] that holds the snapshot
  *   bytes. Owns serialization; the decorator does not touch the snapshot
  *   format the delegate uses.
  * @param keyProvider source of the HMAC key. See [HmacKeyProvider].
- * @param signatureStore persistence for the signature blob. See
- *   [SignatureStore].
- * @param onTamperDetected invoked from [read] when verification fails. Runs
- *   on whatever dispatcher the read is invoked from. Intended for logging /
- *   telemetry; do not throw.
+ * @param signatureStore per-entitlement-key persistence for signature blobs.
+ *   See [SignatureStore].
+ * @param keyToStorageId serializes `K` to a stable string identifier. The
+ *   string is used both as the lookup key in [signatureStore] and is included
+ *   in the v2 canonical bytes. Must be stable across app upgrades (renaming
+ *   an enum constant breaks verification of that entitlement's old sigs).
+ * @param onTamperDetected invoked from [readAll] when verification fails for
+ *   a key. Receives the entitlement key (as serialized via [keyToStorageId])
+ *   and the typed event. Runs on whatever dispatcher the read is invoked
+ *   from. Intended for logging / telemetry; do not throw.
  */
-public class SignedEntitlementStorage(
-    private val delegate: EntitlementStorage,
+public class SignedEntitlementStorage<K : Any>(
+    private val delegate: EntitlementStorage<K>,
     private val keyProvider: HmacKeyProvider,
     private val signatureStore: SignatureStore,
-    private val onTamperDetected: (TamperEvent) -> Unit = {},
-) : EntitlementStorage {
+    private val keyToStorageId: (K) -> String,
+    private val onTamperDetected: (entitlementKey: String, event: TamperEvent) -> Unit = { _, _ -> },
+) : EntitlementStorage<K> {
 
-    override suspend fun read(): EntitlementSnapshot? {
-        val snapshot = delegate.read() ?: return null
+    override suspend fun readAll(): Map<K, EntitlementSnapshot> {
+        val raw = delegate.readAll()
+        if (raw.isEmpty()) return emptyMap()
+        val verified = LinkedHashMap<K, EntitlementSnapshot>(raw.size)
+        for ((key, snapshot) in raw) {
+            val entitlementKey = keyToStorageId(key)
+            val ok = verifySnapshot(entitlementKey, snapshot)
+            if (ok) verified[key] = snapshot
+        }
+        return verified
+    }
 
-        val blob = signatureStore.readSignature()
+    override suspend fun write(key: K, snapshot: EntitlementSnapshot) {
+        val entitlementKey = keyToStorageId(key)
+        // Sign first (no side effects), then persist. A keyProvider failure —
+        // e.g., transient AndroidKeyStore key generation flake, ServerSeeded
+        // fetcher throwing — would otherwise leave delegate updated with a
+        // snapshot the next read can't verify. Computing the blob up front
+        // makes signing failures fully retriable.
+        val blob = signSnapshot(snapshot, entitlementKey, keyProvider)
+        delegate.write(key, snapshot)
+        signatureStore.writeSignature(entitlementKey, blob)
+    }
+
+    private suspend fun verifySnapshot(entitlementKey: String, snapshot: EntitlementSnapshot): Boolean {
+        val blob = signatureStore.readSignature(entitlementKey)
         if (blob == null) {
-            onTamperDetected(TamperEvent.MissingSignature)
-            return null
+            onTamperDetected(entitlementKey, TamperEvent.MissingSignature)
+            return false
         }
         // Wire format is fixed: VERSION_PREFIX_SIZE + HMAC_SHA256_SIZE = exactly
         // SIGNATURE_BLOB_SIZE bytes. Anything else is malformed — including
         // trailing bytes, which would otherwise be silently folded into the
         // HMAC slice and verified against the wrong shape.
         if (blob.size != SIGNATURE_BLOB_SIZE) {
-            onTamperDetected(TamperEvent.InvalidSignature)
-            return null
+            onTamperDetected(entitlementKey, TamperEvent.InvalidSignature)
+            return false
         }
 
         val version = ByteBuffer.wrap(blob, 0, VERSION_PREFIX_SIZE).int
         if (version < MIN_VERSION || version > SnapshotCanonicalBytes.MAX_SUPPORTED_VERSION) {
-            onTamperDetected(TamperEvent.UnsupportedVersion(version))
-            return null
+            onTamperDetected(entitlementKey, TamperEvent.UnsupportedVersion(version))
+            return false
         }
 
-        val canonical = SnapshotCanonicalBytes.encode(snapshot, version)
+        val canonical = SnapshotCanonicalBytes.encode(snapshot, entitlementKey, version)
         val hmac = blob.copyOfRange(VERSION_PREFIX_SIZE, blob.size)
         val verified = keyProvider.verify(canonical, hmac)
         if (!verified) {
-            onTamperDetected(TamperEvent.InvalidSignature)
-            return null
+            onTamperDetected(entitlementKey, TamperEvent.InvalidSignature)
+            return false
         }
-        return snapshot
-    }
-
-    override suspend fun write(snapshot: EntitlementSnapshot) {
-        // Sign first (no side effects), then persist. A keyProvider failure —
-        // e.g., transient AndroidKeyStore key generation flake, ServerSeeded
-        // fetcher throwing — would otherwise leave delegate updated with a
-        // snapshot the next read can't verify. Computing the blob up front
-        // makes signing failures fully retriable.
-        val blob = signSnapshot(snapshot, keyProvider)
-        delegate.write(snapshot)
-        signatureStore.writeSignature(blob)
+        return true
     }
 
     public companion object {
 
         /**
-         * Migrates an existing unsigned snapshot — typically left over from a
-         * release that didn't yet wrap [delegate] in [SignedEntitlementStorage]
-         * — by reading it once and writing a fresh signature blob via
-         * [signatureStore]. Subsequent reads through a normally-configured
-         * [SignedEntitlementStorage] over the same trio of dependencies will
-         * succeed without firing the tamper callback.
+         * Migrates an existing unsigned snapshot for [entitlementKey] —
+         * typically left over from a release that didn't yet wrap [delegate]
+         * in [SignedEntitlementStorage] — by reading it once and writing a
+         * fresh signature blob via [signatureStore]. Subsequent reads through
+         * a normally-configured [SignedEntitlementStorage] over the same trio
+         * of dependencies will succeed without firing the tamper callback.
          *
-         * Intended for one-shot use on first launch after upgrade. The caller
-         * is responsible for guarding with a "migration applied" marker (e.g.,
-         * a SharedPreferences boolean) so this runs at most once per install.
-         * `migrateUnsignedSnapshot` is `suspend` (it reads and writes through
-         * the same dispatchers your storage normally uses), so call it from a
-         * coroutine — and call it **before** constructing the
-         * [SignedEntitlementStorage] that wraps the same trio, so the cache's
-         * first read sees the freshly-written signature instead of firing
-         * [TamperEvent.MissingSignature]:
-         *
-         * ```kotlin
-         * suspend fun bootstrapEntitlementStorage(): EntitlementStorage {
-         *     val rawStorage = MyDataStoreEntitlementStorage(context)
-         *     val keyProvider = KeystoreBackedKeyProvider.create()
-         *     val sigStore = SharedPreferencesSignatureStore(context)
-         *
-         *     if (!prefs.getBoolean("entitlement_signed_migrated", false)) {
-         *         SignedEntitlementStorage.migrateUnsignedSnapshot(
-         *             rawStorage, keyProvider, sigStore,
-         *         )
-         *         prefs.edit().putBoolean("entitlement_signed_migrated", true).apply()
-         *     }
-         *     return SignedEntitlementStorage(rawStorage, keyProvider, sigStore)
-         * }
-         * ```
+         * Intended for one-shot use on first launch after upgrade, per
+         * entitlement. The caller is responsible for guarding with a
+         * "migration applied" marker (e.g., a SharedPreferences boolean) so
+         * this runs at most once per install. `migrateUnsignedSnapshot` is
+         * `suspend` (it reads and writes through the same dispatchers your
+         * storage normally uses), so call it from a coroutine — and call it
+         * **before** constructing the [SignedEntitlementStorage] that wraps
+         * the same trio, so the cache's first read sees the freshly-written
+         * signature instead of firing [TamperEvent.MissingSignature].
          *
          * # Idempotency
          *
-         * If [signatureStore] already contains a blob, this method does
-         * nothing and returns `false` — calling it more than once is safe.
+         * If [signatureStore] already contains a blob for [entitlementKey],
+         * this method does nothing and returns `false` — calling it more than
+         * once is safe.
          *
          * # Security tradeoff
          *
@@ -200,32 +225,46 @@ public class SignedEntitlementStorage(
          * ([TamperEvent.MissingSignature] → null read → live re-confirm) if
          * pre-upgrade tampering is in your threat model.
          *
+         * # Multi-entitlement
+         *
+         * Each key migrates independently. Loop your known keys; the helper
+         * is no-op for any key whose snapshot is already absent from
+         * [delegate].
+         *
+         * @param entitlementKey the serialized entitlement key string (the
+         *   same one a [SignedEntitlementStorage] would compute via its
+         *   `keyToStorageId` lambda for the corresponding `K`). For a
+         *   single-entitlement migration from v0.1.x, this is whatever your
+         *   new `keyToStorageId(yourSingleKey)` produces.
          * @return `true` if a snapshot was found and a signature was written;
          *   `false` if the delegate had no snapshot to migrate, or if a
-         *   signature already existed.
+         *   signature already existed for [entitlementKey].
          */
-        public suspend fun migrateUnsignedSnapshot(
-            delegate: EntitlementStorage,
+        public suspend fun <K : Any> migrateUnsignedSnapshot(
+            entitlementKey: String,
+            entitlementCacheKey: K,
+            delegate: EntitlementStorage<K>,
             keyProvider: HmacKeyProvider,
             signatureStore: SignatureStore,
         ): Boolean {
             // Idempotent: skip the (potentially expensive) snapshot read when a
             // signature is already in place. Repeated calls become a single
             // signature read.
-            if (signatureStore.readSignature() != null) return false
-            val snapshot = delegate.read() ?: return false
+            if (signatureStore.readSignature(entitlementKey) != null) return false
+            val snapshot = delegate.readAll()[entitlementCacheKey] ?: return false
 
-            val blob = signSnapshot(snapshot, keyProvider)
-            signatureStore.writeSignature(blob)
+            val blob = signSnapshot(snapshot, entitlementKey, keyProvider)
+            signatureStore.writeSignature(entitlementKey, blob)
             return true
         }
 
         private suspend fun signSnapshot(
             snapshot: EntitlementSnapshot,
+            entitlementKey: String,
             keyProvider: HmacKeyProvider,
         ): ByteArray {
             val version = SnapshotCanonicalBytes.CURRENT_VERSION
-            val canonical = SnapshotCanonicalBytes.encode(snapshot, version)
+            val canonical = SnapshotCanonicalBytes.encode(snapshot, entitlementKey, version)
             val hmac = keyProvider.sign(canonical)
             // The wire format is anchored to HMAC-SHA256's 32-byte output; an
             // HmacKeyProvider that returns a different size would silently
@@ -245,16 +284,18 @@ public class SignedEntitlementStorage(
         private const val HMAC_SHA256_SIZE = 32
         private const val SIGNATURE_BLOB_SIZE = VERSION_PREFIX_SIZE + HMAC_SHA256_SIZE
 
-        // Lowest version this build will accept on read. SnapshotCanonicalBytes
-        // currently knows v1; allowing v0 or negatives would let a corrupted /
-        // forged blob crash read() via encode() throwing.
+        // Lowest version this build will accept on read. v1 (single-entitlement
+        // legacy) and v2 (multi-entitlement, key in canonical bytes) are both
+        // supported. Allowing v0 or negatives would let a corrupted / forged
+        // blob crash read() via encode() throwing.
         private const val MIN_VERSION = 1
     }
 }
 
 /**
- * Reason that [SignedEntitlementStorage.read] couldn't return a valid
- * snapshot. Passed to the `onTamperDetected` callback.
+ * Reason that [SignedEntitlementStorage.readAll] couldn't return a valid
+ * snapshot for a given entitlement key. Passed to the `onTamperDetected`
+ * callback alongside the affected key.
  *
  * Distinguishing these cases lets consumer telemetry route them differently:
  * [MissingSignature] is usually benign (one-time migration), while
@@ -263,30 +304,32 @@ public class SignedEntitlementStorage(
 public sealed interface TamperEvent {
 
     /**
-     * The delegate returned a snapshot, but [SignatureStore] held no
-     * signature. Typically a one-time first read after upgrading to signed
-     * storage from a release that wasn't wrapping its [EntitlementStorage].
-     * See [SignedEntitlementStorage.migrateUnsignedSnapshot] for an opt-in
+     * The delegate returned a snapshot for this entitlement key, but
+     * [SignatureStore] held no signature for it. Typically a one-time first
+     * read after upgrading to signed storage from a release that wasn't
+     * wrapping its [EntitlementStorage]. See
+     * [SignedEntitlementStorage.migrateUnsignedSnapshot] for an opt-in
      * migration path that avoids this case.
      */
     public object MissingSignature : TamperEvent
 
     /**
-     * The delegate returned a snapshot and the signature blob was present and
-     * the right shape, but HMAC verification failed. Strong tamper indicator
-     * — either the snapshot or the signature was modified after the last
-     * legitimate write. (Also fires if the blob is truncated below the
-     * minimum size; that's still consistent with a tamper attempt that
-     * corrupted the signature file.)
+     * The delegate returned a snapshot for this entitlement key and the
+     * signature blob was present and the right shape, but HMAC verification
+     * failed. Strong tamper indicator — either the snapshot or the signature
+     * was modified after the last legitimate write, or a cross-key sig swap
+     * was attempted. (Also fires if the blob is truncated below or extended
+     * beyond the expected size; that's still consistent with a tamper
+     * attempt that corrupted the signature file.)
      */
     public object InvalidSignature : TamperEvent
 
     /**
-     * The signature blob declared a version this build of the library can't
-     * verify (either above the highest version this build supports or below
-     * `1`). Implies forgery, blob corruption, or a forward-incompatible blob
-     * written by a newer library version that the app was later downgraded
-     * from.
+     * The signature blob for this entitlement key declared a version this
+     * build of the library can't verify (either above the highest version
+     * this build supports or below `1`). Implies forgery, blob corruption,
+     * or a forward-incompatible blob written by a newer library version that
+     * the app was later downgraded from.
      */
     public data class UnsupportedVersion(val version: Int) : TamperEvent
 }

--- a/billing/src/main/kotlin/com/kanetik/billing/entitlement/signed/SnapshotCanonicalBytes.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/entitlement/signed/SnapshotCanonicalBytes.kt
@@ -8,7 +8,9 @@ import java.nio.charset.StandardCharsets
  * Internal helper: deterministic byte encoding of an [EntitlementSnapshot]
  * tagged with a schema version, used as the input to HMAC sign / verify.
  *
- * # Wire format (v1)
+ * # Wire formats
+ *
+ * ## v1 (legacy — single-entitlement)
  * ```
  * canonical_v1 := version_be(4 bytes)
  *              || is_entitled(1 byte: 0 or 1)
@@ -17,6 +19,29 @@ import java.nio.charset.StandardCharsets
  *              || token_utf8(token_len bytes; absent when token_len == -1)
  * ```
  *
+ * Written by the v0.1.x single-entitlement cache. Does **not** include the
+ * entitlement key (there was only one entitlement at the time). Read-only on
+ * this build — new writes always use [CURRENT_VERSION]. A consumer upgrading
+ * from v0.1.x with `K = Unit` (or any single-key shape) will see their old
+ * v1 sigs continue to verify, because the v1 encoder doesn't reference the
+ * entitlement key.
+ *
+ * ## v2 (current — multi-entitlement)
+ * ```
+ * canonical_v2 := version_be(4 bytes)
+ *              || key_len(4 bytes BE int; >= 0)
+ *              || key_utf8(key_len bytes)
+ *              || is_entitled(1 byte: 0 or 1)
+ *              || confirmed_at_ms(8 bytes BE long)
+ *              || token_len(4 bytes BE int; -1 for null)
+ *              || token_utf8(token_len bytes; absent when token_len == -1)
+ * ```
+ *
+ * Includes the serialized entitlement key (via [SignedEntitlementStorage]'s
+ * `keyToStorageId`) in the canonical bytes. This makes cross-key signature
+ * swap detectable — a v2 sig for entitlement A applied to a v2 snapshot for
+ * entitlement B fails verification because the key bytes differ.
+ *
  * The version int is part of the bytes the HMAC authenticates (not just a
  * separately-stored prefix), so an attacker can't downgrade a v2 signature
  * to v1 or vice versa without breaking verification.
@@ -24,17 +49,18 @@ import java.nio.charset.StandardCharsets
  * # Adding a field to [EntitlementSnapshot]
  *
  * 1. Add the field to [EntitlementSnapshot] (must be nullable or have a
- *    documented absent-default consistent with v1 reads — additive evolution
- *    only, no breaking shape changes).
- * 2. Bump [CURRENT_VERSION] (e.g., 1 → 2).
- * 3. Add a `2 -> ...` branch to [encode] that writes the new field.
- * 4. Leave the `1 -> ...` branch untouched. It keeps verifying old signatures
- *    by canonical-encoding only the v1-known fields. A snapshot that was
- *    signed at v1 will continue to verify after the library upgrade because
- *    the deserialized snapshot's new field defaults to its absent-value, which
- *    the v1 encoder ignores.
- * 5. Add a roundtrip test: sign at v1, read back through v2 code, verify still
- *    passes. Sign at v2, verify v2.
+ *    documented absent-default consistent with prior reads — additive
+ *    evolution only, no breaking shape changes).
+ * 2. Bump [CURRENT_VERSION] (e.g., 2 → 3).
+ * 3. Add a `3 -> ...` branch to [encode] that writes the new field.
+ * 4. Leave the `2 -> ...` and `1 -> ...` branches untouched. They keep
+ *    verifying old signatures by canonical-encoding only the version-known
+ *    fields. A snapshot signed at an older version will continue to verify
+ *    after the library upgrade because the deserialized snapshot's new field
+ *    defaults to its absent-value, which the old encoder ignores.
+ * 5. Add a roundtrip test: sign at the new version, verify the new version.
+ *    Sign at each prior version, read back through the new encode, verify
+ *    still passes.
  *
  * The verifier does not own snapshot deserialization (the consumer's
  * [com.kanetik.billing.entitlement.EntitlementStorage] does). It receives the
@@ -47,22 +73,25 @@ internal object SnapshotCanonicalBytes {
      * The version stamped into all newly-written signatures. Bump when adding
      * a field to [EntitlementSnapshot]; see the file-level KDoc.
      */
-    const val CURRENT_VERSION: Int = 1
+    const val CURRENT_VERSION: Int = 2
 
     /** Largest version this build of the library knows how to verify. */
     const val MAX_SUPPORTED_VERSION: Int = CURRENT_VERSION
 
     /**
-     * Encodes [snapshot] for signing at the named [version].
+     * Encodes [snapshot] for signing at the named [version], scoped to
+     * [entitlementKey]. The v1 encoder ignores [entitlementKey] (single-
+     * entitlement legacy format); v2+ includes it in the canonical bytes.
      *
      * @throws IllegalArgumentException if [version] is unknown to this build.
      *   Callers verifying a persisted signature should range-check the parsed
      *   version against [MAX_SUPPORTED_VERSION] before invoking and surface a
      *   tamper / unsupported-version event instead of letting this throw.
      */
-    fun encode(snapshot: EntitlementSnapshot, version: Int): ByteArray {
+    fun encode(snapshot: EntitlementSnapshot, entitlementKey: String, version: Int): ByteArray {
         return when (version) {
             1 -> encodeV1(snapshot)
+            2 -> encodeV2(snapshot, entitlementKey)
             else -> throw IllegalArgumentException("Unknown snapshot version: $version")
         }
     }
@@ -76,6 +105,28 @@ internal object SnapshotCanonicalBytes {
         val totalSize = 4 + 1 + 8 + 4 + tokenSerializedSize
         val buffer = ByteBuffer.allocate(totalSize)
         buffer.putInt(1)
+        buffer.put(if (snapshot.isEntitled) 1.toByte() else 0.toByte())
+        buffer.putLong(snapshot.confirmedAtMs)
+        buffer.putInt(tokenLen)
+        if (tokenBytes != null) {
+            buffer.put(tokenBytes)
+        }
+        return buffer.array()
+    }
+
+    private fun encodeV2(snapshot: EntitlementSnapshot, entitlementKey: String): ByteArray {
+        val keyBytes = entitlementKey.toByteArray(StandardCharsets.UTF_8)
+        val tokenBytes: ByteArray? = snapshot.purchaseToken?.toByteArray(StandardCharsets.UTF_8)
+        val tokenLen = tokenBytes?.size ?: -1
+        val tokenSerializedSize = tokenBytes?.size ?: 0
+
+        // 4 (version) + 4 (keyLen) + keyBytes + 1 (isEntitled) + 8 (confirmedAtMs)
+        //   + 4 (tokenLen) + tokenBytes
+        val totalSize = 4 + 4 + keyBytes.size + 1 + 8 + 4 + tokenSerializedSize
+        val buffer = ByteBuffer.allocate(totalSize)
+        buffer.putInt(2)
+        buffer.putInt(keyBytes.size)
+        buffer.put(keyBytes)
         buffer.put(if (snapshot.isEntitled) 1.toByte() else 0.toByte())
         buffer.putLong(snapshot.confirmedAtMs)
         buffer.putInt(tokenLen)

--- a/billing/src/main/kotlin/com/kanetik/billing/ext/FlowParamsExtensions.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/ext/FlowParamsExtensions.kt
@@ -45,15 +45,19 @@ import com.android.billingclient.api.ProductDetails
  *
  * ## Multi-quantity (Play Console + `purchase.quantity`)
  *
- * Multi-quantity for consumables is configured per-product in Play Console
- * (*Multi-quantity purchases* flag) and rendered by Play's own purchase dialog
- * — there's no `setPurchaseQuantity` knob on the PBL 9 client. The dialog lets
- * the user pick the unit count; the resulting [com.android.billingclient.api.Purchase]
- * carries `purchase.quantity` (defaults to 1). Your entitlement-grant code must
- * read that field and grant `quantity` units, not 1. The library handles
- * acknowledgement correctly for any quantity (Play's consume API consumes the
- * whole purchase regardless), so only your wallet-ledger code needs the
- * awareness.
+ * Multi-quantity applies to **consumables** — a multi-quantity purchase
+ * isn't a multi-grant entitlement, it's N units credited to a wallet/ledger.
+ * Configured per-product in Play Console (*Multi-quantity purchases* flag)
+ * and rendered by Play's own purchase dialog — there's no
+ * `setPurchaseQuantity` knob on the PBL 9 client. The dialog lets the user
+ * pick the unit count; the resulting [com.android.billingclient.api.Purchase]
+ * carries `purchase.quantity` (defaults to 1). Your **wallet/ledger credit
+ * code** must read that field and credit `quantity` units, not 1. The
+ * library handles acknowledgement correctly for any quantity (Play's
+ * consume API consumes the whole purchase regardless), so only your
+ * wallet-ledger code needs the awareness — `EntitlementCache` is not
+ * involved (consumables bypass the cache via `productKeySelector` returning
+ * `null` for them; see the consumables guide).
  *
  * See the [Consumables ledger guide](https://kanetik.github.io/billing-library/guides/consumables/)
  * for the wallet-on-the-side pattern that pairs with multi-quantity consumables.

--- a/billing/src/main/kotlin/com/kanetik/billing/ext/FlowParamsExtensions.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/ext/FlowParamsExtensions.kt
@@ -25,23 +25,38 @@ import com.android.billingclient.api.ProductDetails
  * ## Offer selection
  *
  * PBL 8.0+ supports one-time products with **multiple offers** (e.g. pre-orders,
- * alternative price tiers). The default [offerSelector] picks the first available
- * offer, which is correct for the dominant case where a product has a single
- * auto-migrated offer entry.
+ * alternative price tiers, rentals). The default [offerSelector] picks the first
+ * available offer, which is correct for the dominant case where a product has a
+ * single auto-migrated offer entry.
  *
  * For products configured with multiple offers, override [offerSelector] to pick
- * the right one — e.g. matching by `offerId`, picking a pre-order over a
- * standard purchase, or applying region-specific logic:
+ * the right one — e.g. matching by `offerId`, picking a pre-order over a standard
+ * purchase via [isPreorder], or applying region-specific logic:
  *
  * ```
  * productDetails.toOneTimeFlowParams(
  *     offerSelector = { offers ->
- *         offers.firstOrNull { it.offerId == "spring-promo" }
+ *         offers.firstOrNull { it.isPreorder }
  *             ?: offers.firstOrNull()
  *     },
- *     obfuscatedAccountId = userId
+ *     obfuscatedAccountId = userId,
  * )
  * ```
+ *
+ * ## Multi-quantity (Play Console + `purchase.quantity`)
+ *
+ * Multi-quantity for consumables is configured per-product in Play Console
+ * (*Multi-quantity purchases* flag) and rendered by Play's own purchase dialog
+ * — there's no `setPurchaseQuantity` knob on the PBL 9 client. The dialog lets
+ * the user pick the unit count; the resulting [com.android.billingclient.api.Purchase]
+ * carries `purchase.quantity` (defaults to 1). Your entitlement-grant code must
+ * read that field and grant `quantity` units, not 1. The library handles
+ * acknowledgement correctly for any quantity (Play's consume API consumes the
+ * whole purchase regardless), so only your wallet-ledger code needs the
+ * awareness.
+ *
+ * See the [Consumables ledger guide](https://kanetik.github.io/billing-library/guides/consumables/)
+ * for the wallet-on-the-side pattern that pairs with multi-quantity consumables.
  *
  * @receiver The [ProductDetails] for a one-time product (queried via
  *   [com.kanetik.billing.BillingActions.queryProductDetails]).
@@ -56,24 +71,6 @@ import com.android.billingclient.api.ProductDetails
  *   to set on the flow params. Receives the full list of offers Play returned for
  *   the product; returns the chosen offer (or `null` to omit `setOfferToken`).
  *   Defaults to picking the first available offer.
- *
- * ## Source-compat trade-off
- *
- * Adding [obfuscatedProfileId] necessarily breaks one of two pre-existing
- * Kotlin call patterns. We chose to break the rarer one:
- *  - **Trailing-lambda preserved** — `product.toOneTimeFlowParams { selector }`
- *    and `product.toOneTimeFlowParams(accountId) { selector }` continue to
- *    compile; the trailing lambda binds to the still-last [offerSelector].
- *  - **Positional 2-arg `(accountId, selector)` broken** — calls like
- *    `product.toOneTimeFlowParams("user-id", customSelector)` now bind the
- *    second argument to [obfuscatedProfileId] (a `String?`), producing a
- *    type-mismatch compile error. Migration: switch to named args
- *    (`obfuscatedAccountId = ..., offerSelector = ...`) — the canonical
- *    style this KDoc has always recommended.
- *
- * Trailing-lambda is the idiomatic Kotlin pattern for callbacks; preserving
- * it was the higher priority. Java callers see the new parameter as required
- * (no `@JvmOverloads` bridge); pass `null` explicitly or rebuild.
  */
 public fun ProductDetails.toOneTimeFlowParams(
     obfuscatedAccountId: String? = null,
@@ -101,3 +98,40 @@ public fun ProductDetails.toOneTimeFlowParams(
 
     return builder.build()
 }
+
+/**
+ * Returns `true` if this one-time-product offer is a pre-order — Play hasn't
+ * fulfilled it yet, and the user is signing up to be charged on a future release
+ * date. PBL 8.1+ exposes pre-order metadata via `getPreorderDetails()`; this
+ * extension is sugar over the null-check.
+ *
+ * Pre-order offers have a few wrinkles worth knowing:
+ *
+ *  - The purchase shows up as [com.kanetik.billing.FlowOutcome.Pending] until
+ *    Play fulfills it on the release date — **do not grant entitlement** on
+ *    that pending event. Wait for the matching
+ *    [com.kanetik.billing.OwnedPurchases.Live] update that arrives when the
+ *    fulfillment lands.
+ *  - The user can cancel a pending pre-order from the Play Store before the
+ *    release date; Play surfaces the cancellation via Voided Purchases API
+ *    server-side (no client event today). Apps that pre-grant feature access
+ *    on pre-order signup should reconcile against the Voided Purchases API
+ *    via their backend before treating the entitlement as durable.
+ *  - One product can carry both pre-order and standard offers
+ *    simultaneously. Pass an [offerSelector] to `toOneTimeFlowParams` that
+ *    branches on [isPreorder] to drive the user into the right one.
+ *
+ * Example:
+ *
+ * ```kotlin
+ * val params = productDetails.toOneTimeFlowParams(
+ *     offerSelector = { offers ->
+ *         val preorder = offers.firstOrNull { it.isPreorder }
+ *         val regular = offers.firstOrNull { !it.isPreorder }
+ *         if (userOptedIntoPreorder) preorder ?: regular else regular ?: preorder
+ *     }
+ * )
+ * ```
+ */
+public val ProductDetails.OneTimePurchaseOfferDetails.isPreorder: Boolean
+    get() = preorderDetails != null

--- a/billing/src/main/kotlin/com/kanetik/billing/ext/PurchaseFlowCoordinator.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/ext/PurchaseFlowCoordinator.kt
@@ -60,7 +60,7 @@ import java.util.concurrent.atomic.AtomicBoolean
  *
  * - Doesn't acknowledge or consume purchases — that's the caller's job once a
  *   [com.kanetik.billing.OwnedPurchases.Live] arrives.
- * - Doesn't decide premium-grant rules — that's app business logic.
+ * - Doesn't decide entitlement-grant rules — that's app business logic.
  * - Doesn't track analytics events — wrap [launch] with your own analytics layer
  *   if needed.
  *

--- a/billing/src/main/kotlin/com/kanetik/billing/security/PurchaseVerifier.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/security/PurchaseVerifier.kt
@@ -25,9 +25,10 @@ import java.security.spec.X509EncodedKeySpec
  * ## Why verify
  *
  * Without signature verification, any client able to forge a Play Store purchase
- * response could grant themselves premium for free. Verification is the difference
- * between "anyone with `adb` can flip the premium flag" and "you'd need Google's
- * signing key to forge a grant." Take the 2 minutes to wire this up.
+ * response could grant themselves a paid entitlement for free. Verification is
+ * the difference between "anyone with `adb` can flip the entitlement flag" and
+ * "you'd need Google's signing key to forge a grant." Take the 2 minutes to
+ * wire this up.
  *
  * ## Usage
  *

--- a/billing/src/test/kotlin/com/kanetik/billing/entitlement/EntitlementCacheTest.kt
+++ b/billing/src/test/kotlin/com/kanetik/billing/entitlement/EntitlementCacheTest.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
@@ -24,18 +24,32 @@ import org.junit.Test
 @OptIn(ExperimentalCoroutinesApi::class)
 class EntitlementCacheTest {
 
-    private val premiumProductId = "premium_lifetime"
-    private val premiumPredicate: (Purchase) -> Boolean = { it.products.contains(premiumProductId) }
+    // Multi-entitlement-friendly: a simple sealed pair of keys so tests cover
+    // the per-key semantics (independent grace, per-key revocation matching,
+    // hydration of multiple snapshots, etc.). Single-key tests just use ONE.
+    private enum class TestKey { ONE, TWO }
+
+    private val productIdOne = "shop_unlock_one"
+    private val productIdTwo = "shop_unlock_two"
+
+    private val keySelector: (Purchase) -> TestKey? = { purchase ->
+        when {
+            productIdOne in purchase.products -> TestKey.ONE
+            productIdTwo in purchase.products -> TestKey.TWO
+            else -> null
+        }
+    }
 
     @Test
-    fun `Live with matching purchase transitions to Granted and persists snapshot`() = runTest {
+    fun `Live with matching purchase transitions that key to Granted and persists snapshot`() = runTest {
         val (cache, updates, storage, _, job) = newCache()
 
-        updates.emit(OwnedPurchases.Live(listOf(fakePurchase(productId = premiumProductId, purchaseToken = "tok1"))))
+        updates.emit(OwnedPurchases.Live(listOf(fakePurchase(productId = productIdOne, purchaseToken = "tok1"))))
         runCurrent()
 
-        assertThat(cache.state.value).isEqualTo(EntitlementState.Granted)
-        assertThat(storage.lastWritten).isEqualTo(
+        assertThat(cache.state.value[TestKey.ONE]).isEqualTo(EntitlementState.Granted)
+        assertThat(cache.state.value[TestKey.TWO]).isNull()
+        assertThat(storage.lastWritten(TestKey.ONE)).isEqualTo(
             EntitlementSnapshot(
                 isEntitled = true,
                 confirmedAtMs = INITIAL_CLOCK,
@@ -47,72 +61,81 @@ class EntitlementCacheTest {
     }
 
     @Test
-    fun `Recovered with matching purchase transitions to Granted and persists snapshot`() = runTest {
+    fun `Recovered with matching purchase transitions that key to Granted and persists snapshot`() = runTest {
         val (cache, updates, storage, _, job) = newCache()
 
-        updates.emit(OwnedPurchases.Recovered(listOf(fakePurchase(productId = premiumProductId, purchaseToken = "tok2"))))
+        updates.emit(OwnedPurchases.Recovered(listOf(fakePurchase(productId = productIdOne, purchaseToken = "tok2"))))
         runCurrent()
 
-        assertThat(cache.state.value).isEqualTo(EntitlementState.Granted)
-        assertThat(storage.lastWritten).isEqualTo(
-            EntitlementSnapshot(
-                isEntitled = true,
-                confirmedAtMs = INITIAL_CLOCK,
-                purchaseToken = "tok2",
+        assertThat(cache.state.value[TestKey.ONE]).isEqualTo(EntitlementState.Granted)
+        assertThat(storage.lastWritten(TestKey.ONE)?.purchaseToken).isEqualTo("tok2")
+
+        job.cancelAndJoin()
+    }
+
+    @Test
+    fun `Live containing multiple matching purchases grants all matching keys`() = runTest {
+        val (cache, updates, storage, _, job) = newCache()
+
+        updates.emit(
+            OwnedPurchases.Live(
+                listOf(
+                    fakePurchase(productId = productIdOne, purchaseToken = "tok-one"),
+                    fakePurchase(productId = productIdTwo, purchaseToken = "tok-two"),
+                ),
             ),
         )
+        runCurrent()
+
+        assertThat(cache.state.value[TestKey.ONE]).isEqualTo(EntitlementState.Granted)
+        assertThat(cache.state.value[TestKey.TWO]).isEqualTo(EntitlementState.Granted)
+        assertThat(storage.lastWritten(TestKey.ONE)?.purchaseToken).isEqualTo("tok-one")
+        assertThat(storage.lastWritten(TestKey.TWO)?.purchaseToken).isEqualTo("tok-two")
 
         job.cancelAndJoin()
     }
 
     @Test
     fun `Recovered with no matching purchase does NOT revoke a Granted snapshot`() = runTest {
-        // Recovered emits only PURCHASED && !isAcknowledged, filtered against
-        // the library's acknowledgedTokens set (PR #10). An already-acked
-        // entitling purchase will never appear in Recovered; treating an
-        // empty Recovered as "Play revoked the entitlement" would falsely
-        // revoke entitled-but-acked users. The cache treats Recovered as
-        // grant-only — see EntitlementCache class KDoc.
         val storage = FakeEntitlementStorage(
-            initial = EntitlementSnapshot(
-                isEntitled = true,
-                confirmedAtMs = INITIAL_CLOCK - 1_000L,
-                purchaseToken = "tok-prior",
+            initial = mapOf(
+                TestKey.ONE to EntitlementSnapshot(
+                    isEntitled = true,
+                    confirmedAtMs = INITIAL_CLOCK - 1_000L,
+                    purchaseToken = "tok-prior",
+                ),
             ),
         )
         val (cache, updates, _, _, job) = newCache(storage = storage)
         runCurrent()
-        // Sanity: we hydrated from the snapshot.
-        assertThat(cache.state.value).isEqualTo(EntitlementState.Granted)
+        assertThat(cache.state.value[TestKey.ONE]).isEqualTo(EntitlementState.Granted)
 
-        // An empty Recovered (e.g. all owned purchases are already acked,
-        // so they're filtered out) must NOT revoke. Same for a Recovered
-        // carrying unrelated unacked purchases.
         updates.emit(OwnedPurchases.Recovered(emptyList()))
         runCurrent()
-        assertThat(cache.state.value).isEqualTo(EntitlementState.Granted)
+        assertThat(cache.state.value[TestKey.ONE]).isEqualTo(EntitlementState.Granted)
 
         updates.emit(OwnedPurchases.Recovered(listOf(fakePurchase(productId = "different-product"))))
         runCurrent()
-        assertThat(cache.state.value).isEqualTo(EntitlementState.Granted)
+        assertThat(cache.state.value[TestKey.ONE]).isEqualTo(EntitlementState.Granted)
 
         job.cancelAndJoin()
     }
 
     @Test
-    fun `PurchaseRevoked matching the cached purchaseToken transitions to Revoked`() = runTest {
+    fun `PurchaseRevoked matching a key's cached token revokes only that key`() = runTest {
         val (cache, updates, _, _, job) = newCache()
-        // Establish Granted baseline.
-        val purchase = fakePurchase(productId = premiumProductId, purchaseToken = "premium-tok")
-        updates.emit(OwnedPurchases.Live(listOf(purchase)))
+        // Establish Granted on both keys.
+        updates.emit(OwnedPurchases.Live(listOf(fakePurchase(productId = productIdOne, purchaseToken = "tok-one"))))
+        updates.emit(OwnedPurchases.Live(listOf(fakePurchase(productId = productIdTwo, purchaseToken = "tok-two"))))
         runCurrent()
-        assertThat(cache.state.value).isEqualTo(EntitlementState.Granted)
+        assertThat(cache.state.value[TestKey.ONE]).isEqualTo(EntitlementState.Granted)
+        assertThat(cache.state.value[TestKey.TWO]).isEqualTo(EntitlementState.Granted)
 
-        // Consumer's RTDN→FCM pipeline pushes a revocation for our cached purchase.
-        updates.emit(PurchaseRevoked(purchaseToken = "premium-tok", reason = RevocationReason.Refunded))
+        updates.emit(PurchaseRevoked(purchaseToken = "tok-one", reason = RevocationReason.Refunded))
         runCurrent()
 
-        assertThat(cache.state.value).isEqualTo(EntitlementState.Revoked)
+        assertThat(cache.state.value[TestKey.ONE]).isEqualTo(EntitlementState.Revoked)
+        assertThat(cache.state.value[TestKey.TWO]).isEqualTo(EntitlementState.Granted)
 
         job.cancelAndJoin()
     }
@@ -120,51 +143,49 @@ class EntitlementCacheTest {
     @Test
     fun `PurchaseRevoked for a different token does not affect cached state`() = runTest {
         val (cache, updates, _, _, job) = newCache()
-        val purchase = fakePurchase(productId = premiumProductId, purchaseToken = "premium-tok")
-        updates.emit(OwnedPurchases.Live(listOf(purchase)))
+        updates.emit(OwnedPurchases.Live(listOf(fakePurchase(productId = productIdOne, purchaseToken = "tok-one"))))
         runCurrent()
-        assertThat(cache.state.value).isEqualTo(EntitlementState.Granted)
+        assertThat(cache.state.value[TestKey.ONE]).isEqualTo(EntitlementState.Granted)
 
-        // Revocation arrives for an unrelated purchase the consumer is also tracking.
         updates.emit(PurchaseRevoked(purchaseToken = "some-other-tok", reason = RevocationReason.Chargeback))
         runCurrent()
 
-        assertThat(cache.state.value).isEqualTo(EntitlementState.Granted)
+        assertThat(cache.state.value[TestKey.ONE]).isEqualTo(EntitlementState.Granted)
 
         job.cancelAndJoin()
     }
 
     @Test
-    fun `Failure with BillingUnavailable response code transitions to InGrace BillingUnavailable`() = runTest {
+    fun `Failure with BillingUnavailable transitions every Granted key to InGrace BillingUnavailable`() = runTest {
         val (cache, updates, _, clock, job) = newCache()
-        // Establish Granted baseline so Failure can move us to InGrace.
-        updates.emit(OwnedPurchases.Live(listOf(fakePurchase(productId = premiumProductId))))
+        updates.emit(OwnedPurchases.Live(listOf(fakePurchase(productId = productIdOne))))
+        updates.emit(OwnedPurchases.Live(listOf(fakePurchase(productId = productIdTwo))))
         runCurrent()
-        assertThat(cache.state.value).isEqualTo(EntitlementState.Granted)
 
         updates.emit(FlowOutcome.Failure(billingUnavailableException(), emptyList()))
         runCurrent()
 
-        val state = cache.state.value
-        assertThat(state).isInstanceOf(EntitlementState.InGrace::class.java)
-        val grace = state as EntitlementState.InGrace
-        assertThat(grace.reason).isEqualTo(GraceReason.BillingUnavailable)
-        assertThat(grace.expiresAtMs).isEqualTo(clock() + DEFAULT_BILLING_UNAVAILABLE_MS)
+        for (key in listOf(TestKey.ONE, TestKey.TWO)) {
+            val state = cache.state.value[key]
+            assertThat(state).isInstanceOf(EntitlementState.InGrace::class.java)
+            val grace = state as EntitlementState.InGrace
+            assertThat(grace.reason).isEqualTo(GraceReason.BillingUnavailable)
+            assertThat(grace.expiresAtMs).isEqualTo(clock() + DEFAULT_BILLING_UNAVAILABLE_MS)
+        }
 
         job.cancelAndJoin()
     }
 
     @Test
-    fun `Failure with NetworkError response code transitions to InGrace TransientFailure`() = runTest {
+    fun `Failure with NetworkError transitions every Granted key to InGrace TransientFailure`() = runTest {
         val (cache, updates, _, clock, job) = newCache()
-        updates.emit(OwnedPurchases.Live(listOf(fakePurchase(productId = premiumProductId))))
+        updates.emit(OwnedPurchases.Live(listOf(fakePurchase(productId = productIdOne))))
         runCurrent()
-        assertThat(cache.state.value).isEqualTo(EntitlementState.Granted)
 
         updates.emit(FlowOutcome.Failure(networkErrorException(), emptyList()))
         runCurrent()
 
-        val state = cache.state.value
+        val state = cache.state.value[TestKey.ONE]
         assertThat(state).isInstanceOf(EntitlementState.InGrace::class.java)
         val grace = state as EntitlementState.InGrace
         assertThat(grace.reason).isEqualTo(GraceReason.TransientFailure)
@@ -177,21 +198,17 @@ class EntitlementCacheTest {
     fun `InGrace transitions to Revoked when grace window expires on next emission`() = runTest {
         val mutableClock = MutableClock(INITIAL_CLOCK)
         val (cache, updates, _, _, job) = newCache(clock = mutableClock::value)
-        updates.emit(OwnedPurchases.Live(listOf(fakePurchase(productId = premiumProductId))))
+        updates.emit(OwnedPurchases.Live(listOf(fakePurchase(productId = productIdOne))))
         runCurrent()
         updates.emit(FlowOutcome.Failure(networkErrorException(), emptyList()))
         runCurrent()
-        val grace = cache.state.value as EntitlementState.InGrace
+        val grace = cache.state.value[TestKey.ONE] as EntitlementState.InGrace
 
-        // Advance the clock past the grace window. No tick fires inside this
-        // runCurrent — the next reduce() call re-evaluates expiry on entry.
         mutableClock.advance(grace.expiresAtMs - mutableClock.value + 1L)
-        // Any subsequent emission triggers re-evaluation; pick a benign one
-        // that doesn't otherwise change state (Pending is a no-op).
         updates.emit(FlowOutcome.Pending(emptyList()))
         runCurrent()
 
-        assertThat(cache.state.value).isEqualTo(EntitlementState.Revoked)
+        assertThat(cache.state.value[TestKey.ONE]).isEqualTo(EntitlementState.Revoked)
         job.cancelAndJoin()
     }
 
@@ -203,74 +220,69 @@ class EntitlementCacheTest {
             clock = mutableClock::value,
             graceTickIntervalMs = tickInterval,
         )
-        updates.emit(OwnedPurchases.Live(listOf(fakePurchase(productId = premiumProductId))))
+        updates.emit(OwnedPurchases.Live(listOf(fakePurchase(productId = productIdOne))))
         runCurrent()
         updates.emit(FlowOutcome.Failure(networkErrorException(), emptyList()))
         runCurrent()
-        val grace = cache.state.value as EntitlementState.InGrace
+        val grace = cache.state.value[TestKey.ONE] as EntitlementState.InGrace
 
-        // Advance the virtual time + the clock past the grace window.
-        // Use the test scheduler's advanceTimeBy to fire the tick coroutine,
-        // and synchronise our own clock to match.
         val advanceBy = grace.expiresAtMs - mutableClock.value + tickInterval
         mutableClock.advance(advanceBy)
         testScheduler.advanceTimeBy(advanceBy + 1L)
         runCurrent()
 
-        assertThat(cache.state.value).isEqualTo(EntitlementState.Revoked)
+        assertThat(cache.state.value[TestKey.ONE]).isEqualTo(EntitlementState.Revoked)
         job.cancelAndJoin()
     }
 
     @Test
-    fun `Granted snapshot persists across cache instances via storage`() = runTest {
-        val storage = FakeEntitlementStorage()
+    fun `Granted snapshots persist across cache instances via storage for each key`() = runTest {
+        val storage = FakeEntitlementStorage<TestKey>()
 
-        // First instance: confirm a Live event and let it write through.
         val firstUpdates = MutableSharedFlow<PurchaseEvent>(extraBufferCapacity = 16)
         val firstCache = EntitlementCache(
             purchasesUpdates = firstUpdates,
             storage = storage,
             gracePolicy = defaultPolicy(),
-            productPredicate = premiumPredicate,
+            productKeySelector = keySelector,
             clock = { INITIAL_CLOCK },
             graceTickIntervalMs = 60_000L,
         )
         val firstJob = firstCache.start(this)
         runCurrent()
-        firstUpdates.emit(OwnedPurchases.Live(listOf(fakePurchase(productId = premiumProductId, purchaseToken = "tok-rt"))))
+        firstUpdates.emit(OwnedPurchases.Live(listOf(fakePurchase(productId = productIdOne, purchaseToken = "tok-rt-one"))))
+        firstUpdates.emit(OwnedPurchases.Live(listOf(fakePurchase(productId = productIdTwo, purchaseToken = "tok-rt-two"))))
         runCurrent()
-        assertThat(firstCache.state.value).isEqualTo(EntitlementState.Granted)
+        assertThat(firstCache.state.value[TestKey.ONE]).isEqualTo(EntitlementState.Granted)
+        assertThat(firstCache.state.value[TestKey.TWO]).isEqualTo(EntitlementState.Granted)
         firstJob.cancelAndJoin()
 
-        // Second instance with the same storage hydrates as Granted.
         val secondUpdates = MutableSharedFlow<PurchaseEvent>(extraBufferCapacity = 16)
         val secondCache = EntitlementCache(
             purchasesUpdates = secondUpdates,
             storage = storage,
             gracePolicy = defaultPolicy(),
-            productPredicate = premiumPredicate,
+            productKeySelector = keySelector,
             clock = { INITIAL_CLOCK + 1_000L },
             graceTickIntervalMs = 60_000L,
         )
         val secondJob = secondCache.start(this)
         runCurrent()
-        assertThat(secondCache.state.value).isEqualTo(EntitlementState.Granted)
-        // The persisted snapshot's purchaseToken survived the round trip.
-        assertThat(storage.lastWritten?.purchaseToken).isEqualTo("tok-rt")
+        assertThat(secondCache.state.value[TestKey.ONE]).isEqualTo(EntitlementState.Granted)
+        assertThat(secondCache.state.value[TestKey.TWO]).isEqualTo(EntitlementState.Granted)
+        assertThat(storage.lastWritten(TestKey.ONE)?.purchaseToken).isEqualTo("tok-rt-one")
+        assertThat(storage.lastWritten(TestKey.TWO)?.purchaseToken).isEqualTo("tok-rt-two")
         secondJob.cancelAndJoin()
     }
 
     @Test
     fun `Live with matching product but UNSPECIFIED_STATE does NOT grant entitlement`() = runTest {
         val (cache, updates, _, _, job) = newCache()
-        // PBL's OK callback can include UNSPECIFIED_STATE entries; the listener
-        // routes them to OwnedPurchases.Live alongside genuinely PURCHASED ones.
-        // The cache must not grant entitlement on those — only on PURCHASED.
         updates.emit(
             OwnedPurchases.Live(
                 listOf(
                     fakePurchase(
-                        productId = premiumProductId,
+                        productId = productIdOne,
                         purchaseToken = "unspecified-tok",
                         purchaseState = Purchase.PurchaseState.UNSPECIFIED_STATE,
                     ),
@@ -278,14 +290,13 @@ class EntitlementCacheTest {
             ),
         )
         runCurrent()
-        assertThat(cache.state.value).isEqualTo(EntitlementState.Revoked)
+        assertThat(cache.state.value[TestKey.ONE]).isNull()
 
-        // Sanity: a PURCHASED entry for the same product DOES grant.
         updates.emit(
             OwnedPurchases.Live(
                 listOf(
                     fakePurchase(
-                        productId = premiumProductId,
+                        productId = productIdOne,
                         purchaseToken = "purchased-tok",
                         purchaseState = Purchase.PurchaseState.PURCHASED,
                     ),
@@ -293,7 +304,7 @@ class EntitlementCacheTest {
             ),
         )
         runCurrent()
-        assertThat(cache.state.value).isEqualTo(EntitlementState.Granted)
+        assertThat(cache.state.value[TestKey.ONE]).isEqualTo(EntitlementState.Granted)
 
         job.cancelAndJoin()
     }
@@ -303,47 +314,38 @@ class EntitlementCacheTest {
         val updates = MutableSharedFlow<PurchaseEvent>(extraBufferCapacity = 16)
         val cache = EntitlementCache(
             purchasesUpdates = updates,
-            storage = FakeEntitlementStorage(),
+            storage = FakeEntitlementStorage<TestKey>(),
             gracePolicy = defaultPolicy(),
-            productPredicate = premiumPredicate,
+            productKeySelector = keySelector,
             clock = { INITIAL_CLOCK },
             graceTickIntervalMs = 60_000L,
         )
         val first = cache.start(this)
         val second = cache.start(this)
-        // Both calls hand back the same active Job. Cancelling either stops
-        // the cache; there's only one collector + tick.
         assertThat(second).isSameInstanceAs(first)
         assertThat(first.isActive).isTrue()
         first.cancelAndJoin()
     }
 
     @Test
-    fun `restart drains stale buffered snapshot from cancelled session`() = runTest {
-        // Verifies that a snapshot queued just before the previous start()'s
-        // scope is cancelled doesn't leak into the next session and overwrite
-        // hydrated storage. The CONFLATED writeChannel persists across
-        // restarts; start() must drain it.
-        val storage = FakeEntitlementStorage()
+    fun `restart drains stale buffered snapshots from cancelled session`() = runTest {
+        val storage = FakeEntitlementStorage<TestKey>()
         val updates = MutableSharedFlow<PurchaseEvent>(extraBufferCapacity = 16)
         val cache = EntitlementCache(
             purchasesUpdates = updates,
             storage = storage,
             gracePolicy = defaultPolicy(),
-            productPredicate = premiumPredicate,
+            productKeySelector = keySelector,
             clock = { INITIAL_CLOCK },
             graceTickIntervalMs = 60_000L,
         )
         val first = cache.start(this)
         runCurrent()
-        // Push a snapshot through reduce, but cancel before the writer drains.
-        // The writer is on the same scope, so cancelling first will stop it
-        // before it can write the buffered snapshot.
         cache.reduce(
             OwnedPurchases.Live(
                 listOf(
                     fakePurchase(
-                        productId = premiumProductId,
+                        productId = productIdOne,
                         purchaseToken = "doomed-tok",
                         purchaseState = Purchase.PurchaseState.PURCHASED,
                     ),
@@ -352,37 +354,31 @@ class EntitlementCacheTest {
         )
         first.cancelAndJoin()
 
-        // Pre-seed storage with a different snapshot, then re-start. If the
-        // stale "doomed-tok" snapshot leaked through the channel, it would
-        // overwrite storage's "fresh-tok" after restart's hydration.
-        storage.lastWritten = EntitlementSnapshot(
-            isEntitled = true,
-            confirmedAtMs = INITIAL_CLOCK + 5_000L,
-            purchaseToken = "fresh-tok",
+        storage.put(
+            TestKey.ONE,
+            EntitlementSnapshot(
+                isEntitled = true,
+                confirmedAtMs = INITIAL_CLOCK + 5_000L,
+                purchaseToken = "fresh-tok",
+            ),
         )
         val second = cache.start(this)
         runCurrent()
-        // Give any leaked write a chance to land. (None should.)
         repeat(3) { runCurrent() }
 
-        // Storage should still hold "fresh-tok"; the stale "doomed-tok" was
-        // drained by start() and never written.
-        assertThat(storage.lastWritten?.purchaseToken).isEqualTo("fresh-tok")
+        assertThat(storage.lastWritten(TestKey.ONE)?.purchaseToken).isEqualTo("fresh-tok")
 
         second.cancelAndJoin()
     }
 
     @Test
     fun `start is restartable after the previous Job is cancelled`() = runTest {
-        // Verifies the cache doesn't enter a permanently-dead state when a
-        // start()'s Job (or scope) is cancelled — a second start() retries
-        // hydration + launches a fresh collector.
         val updates = MutableSharedFlow<PurchaseEvent>(extraBufferCapacity = 16)
         val cache = EntitlementCache(
             purchasesUpdates = updates,
-            storage = FakeEntitlementStorage(),
+            storage = FakeEntitlementStorage<TestKey>(),
             gracePolicy = defaultPolicy(),
-            productPredicate = premiumPredicate,
+            productKeySelector = keySelector,
             clock = { INITIAL_CLOCK },
             graceTickIntervalMs = 60_000L,
         )
@@ -390,61 +386,77 @@ class EntitlementCacheTest {
         first.cancelAndJoin()
         assertThat(first.isActive).isFalse()
 
-        // Fresh start should establish a new active Job.
         val second = cache.start(this)
         runCurrent()
         assertThat(second).isNotSameInstanceAs(first)
         assertThat(second.isActive).isTrue()
 
-        // Sanity: the new collector actually processes events.
-        updates.emit(OwnedPurchases.Live(listOf(fakePurchase(productId = premiumProductId, purchaseToken = "after-restart"))))
+        updates.emit(OwnedPurchases.Live(listOf(fakePurchase(productId = productIdOne, purchaseToken = "after-restart"))))
         runCurrent()
-        assertThat(cache.state.value).isEqualTo(EntitlementState.Granted)
+        assertThat(cache.state.value[TestKey.ONE]).isEqualTo(EntitlementState.Granted)
 
         second.cancelAndJoin()
     }
 
     @Test
-    fun `Failure while Revoked stays Revoked - no spurious InGrace`() = runTest {
+    fun `Failure while no key is Granted is a no-op - no spurious InGrace`() = runTest {
         val (cache, updates, _, _, job) = newCache()
-        // Default state is Revoked; no prior Granted observation.
 
         updates.emit(FlowOutcome.Failure(networkErrorException(), emptyList()))
         runCurrent()
 
-        assertThat(cache.state.value).isEqualTo(EntitlementState.Revoked)
+        assertThat(cache.state.value).isEmpty()
         job.cancelAndJoin()
     }
 
     @Test
     fun `Live of an unrelated product does not revoke an existing Granted state`() = runTest {
         val (cache, updates, _, _, job) = newCache()
-        updates.emit(OwnedPurchases.Live(listOf(fakePurchase(productId = premiumProductId))))
+        updates.emit(OwnedPurchases.Live(listOf(fakePurchase(productId = productIdOne))))
         runCurrent()
-        assertThat(cache.state.value).isEqualTo(EntitlementState.Granted)
+        assertThat(cache.state.value[TestKey.ONE]).isEqualTo(EntitlementState.Granted)
 
+        // A consumable currency pack arrives in the Live stream — the selector
+        // returns null for it, so it doesn't grant any key but also must not
+        // revoke the already-granted key.
         updates.emit(OwnedPurchases.Live(listOf(fakePurchase(productId = "coins_pack_50"))))
         runCurrent()
 
-        // Live of a non-premium IAP does not negate entitlement; the cache
-        // treats Live and Recovered as grant-only signals and routes
-        // revocation through PurchaseRevoked + grace expiry instead.
-        assertThat(cache.state.value).isEqualTo(EntitlementState.Granted)
+        assertThat(cache.state.value[TestKey.ONE]).isEqualTo(EntitlementState.Granted)
+        job.cancelAndJoin()
+    }
+
+    @Test
+    fun `stateFor exposes a per-key Flow that surfaces absent keys as Revoked`() = runTest {
+        val (cache, updates, _, _, job) = newCache()
+        // Sanity: TWO is absent from the map.
+        assertThat(cache.state.value[TestKey.TWO]).isNull()
+
+        val collected = mutableListOf<EntitlementState>()
+        val collectorJob = launch { cache.stateFor(TestKey.TWO).collect { collected.add(it) } }
+        runCurrent()
+        assertThat(collected).containsExactly(EntitlementState.Revoked)
+
+        updates.emit(OwnedPurchases.Live(listOf(fakePurchase(productId = productIdTwo))))
+        runCurrent()
+        assertThat(collected).containsExactly(EntitlementState.Revoked, EntitlementState.Granted).inOrder()
+
+        collectorJob.cancelAndJoin()
         job.cancelAndJoin()
     }
 
     // -- Test helpers --------------------------------------------------------
 
     private data class CacheUnderTest(
-        val cache: EntitlementCache,
+        val cache: EntitlementCache<TestKey>,
         val updates: MutableSharedFlow<PurchaseEvent>,
-        val storage: FakeEntitlementStorage,
+        val storage: FakeEntitlementStorage<TestKey>,
         val clock: () -> Long,
         val job: Job,
     )
 
     private suspend fun TestScope.newCache(
-        storage: FakeEntitlementStorage = FakeEntitlementStorage(),
+        storage: FakeEntitlementStorage<TestKey> = FakeEntitlementStorage(),
         clock: () -> Long = { INITIAL_CLOCK },
         graceTickIntervalMs: Long = 60_000L,
     ): CacheUnderTest {
@@ -453,7 +465,7 @@ class EntitlementCacheTest {
             purchasesUpdates = updates,
             storage = storage,
             gracePolicy = defaultPolicy(),
-            productPredicate = premiumPredicate,
+            productKeySelector = keySelector,
             clock = clock,
             graceTickIntervalMs = graceTickIntervalMs,
         )
@@ -484,15 +496,21 @@ class EntitlementCacheTest {
     }
 }
 
-private class FakeEntitlementStorage(
-    initial: EntitlementSnapshot? = null,
-) : EntitlementStorage {
-    var lastWritten: EntitlementSnapshot? = initial
+private class FakeEntitlementStorage<K : Any>(
+    initial: Map<K, EntitlementSnapshot> = emptyMap(),
+) : EntitlementStorage<K> {
+    private val store: MutableMap<K, EntitlementSnapshot> = HashMap(initial)
 
-    override suspend fun read(): EntitlementSnapshot? = lastWritten
+    fun lastWritten(key: K): EntitlementSnapshot? = store[key]
 
-    override suspend fun write(snapshot: EntitlementSnapshot) {
-        lastWritten = snapshot
+    fun put(key: K, snapshot: EntitlementSnapshot) {
+        store[key] = snapshot
+    }
+
+    override suspend fun readAll(): Map<K, EntitlementSnapshot> = HashMap(store)
+
+    override suspend fun write(key: K, snapshot: EntitlementSnapshot) {
+        store[key] = snapshot
     }
 }
 

--- a/billing/src/test/kotlin/com/kanetik/billing/entitlement/signed/SignedEntitlementStorageTest.kt
+++ b/billing/src/test/kotlin/com/kanetik/billing/entitlement/signed/SignedEntitlementStorageTest.kt
@@ -11,174 +11,238 @@ import javax.crypto.spec.SecretKeySpec
 
 class SignedEntitlementStorageTest {
 
-    private val sampleSnapshot = EntitlementSnapshot(
+    private val keyOne = "entitlement_one"
+    private val keyTwo = "entitlement_two"
+
+    private val sampleSnapshotOne = EntitlementSnapshot(
         isEntitled = true,
         confirmedAtMs = 1_700_000_000_000L,
         purchaseToken = "tok-1",
     )
+    private val sampleSnapshotTwo = EntitlementSnapshot(
+        isEntitled = true,
+        confirmedAtMs = 1_700_000_005_000L,
+        purchaseToken = "tok-2",
+    )
 
     @Test
-    fun `write then read roundtrips the same snapshot`() = runTest {
+    fun `write then readAll roundtrips the same snapshot for one key`() = runTest {
         val (storage, delegate, sigStore) = newStorage()
 
-        storage.write(sampleSnapshot)
+        storage.write(keyOne, sampleSnapshotOne)
 
-        assertThat(delegate.lastWritten).isEqualTo(sampleSnapshot)
-        assertThat(sigStore.last).isNotNull()
-        assertThat(storage.read()).isEqualTo(sampleSnapshot)
+        assertThat(delegate.last(keyOne)).isEqualTo(sampleSnapshotOne)
+        assertThat(sigStore.lastFor(keyOne)).isNotNull()
+        assertThat(storage.readAll()).containsExactly(keyOne, sampleSnapshotOne)
     }
 
     @Test
-    fun `read returns null without firing callback when delegate has no snapshot`() = runTest {
-        val tamperEvents = mutableListOf<TamperEvent>()
-        val (storage, _, _) = newStorage(onTamperDetected = { tamperEvents += it })
+    fun `write then readAll roundtrips snapshots for multiple keys`() = runTest {
+        val (storage, _, _) = newStorage()
+        storage.write(keyOne, sampleSnapshotOne)
+        storage.write(keyTwo, sampleSnapshotTwo)
 
-        assertThat(storage.read()).isNull()
+        assertThat(storage.readAll())
+            .containsExactly(keyOne, sampleSnapshotOne, keyTwo, sampleSnapshotTwo)
+    }
+
+    @Test
+    fun `readAll returns empty without firing callback when delegate has no snapshots`() = runTest {
+        val tamperEvents = mutableListOf<Pair<String, TamperEvent>>()
+        val (storage, _, _) = newStorage(onTamperDetected = { key, e -> tamperEvents += key to e })
+
+        assertThat(storage.readAll()).isEmpty()
         assertThat(tamperEvents).isEmpty()
     }
 
     @Test
-    fun `read fires MissingSignature when snapshot present but signature missing`() = runTest {
-        val tamperEvents = mutableListOf<TamperEvent>()
-        val (storage, delegate, _) = newStorage(onTamperDetected = { tamperEvents += it })
+    fun `readAll fires MissingSignature when snapshot present but signature missing`() = runTest {
+        val tamperEvents = mutableListOf<Pair<String, TamperEvent>>()
+        val (storage, delegate, _) = newStorage(onTamperDetected = { key, e -> tamperEvents += key to e })
 
-        delegate.lastWritten = sampleSnapshot
+        delegate.put(keyOne, sampleSnapshotOne)
 
-        assertThat(storage.read()).isNull()
-        assertThat(tamperEvents).containsExactly(TamperEvent.MissingSignature)
+        assertThat(storage.readAll()).isEmpty()
+        assertThat(tamperEvents).containsExactly(keyOne to TamperEvent.MissingSignature)
     }
 
     @Test
-    fun `read fires InvalidSignature when snapshot mutated after signing`() = runTest {
-        val tamperEvents = mutableListOf<TamperEvent>()
-        val (storage, delegate, _) = newStorage(onTamperDetected = { tamperEvents += it })
+    fun `readAll fires InvalidSignature when snapshot mutated after signing`() = runTest {
+        val tamperEvents = mutableListOf<Pair<String, TamperEvent>>()
+        val (storage, delegate, _) = newStorage(onTamperDetected = { key, e -> tamperEvents += key to e })
 
-        storage.write(sampleSnapshot)
-        delegate.lastWritten = sampleSnapshot.copy(isEntitled = false)
+        storage.write(keyOne, sampleSnapshotOne)
+        delegate.put(keyOne, sampleSnapshotOne.copy(isEntitled = false))
 
-        assertThat(storage.read()).isNull()
-        assertThat(tamperEvents).containsExactly(TamperEvent.InvalidSignature)
+        assertThat(storage.readAll()).isEmpty()
+        assertThat(tamperEvents).containsExactly(keyOne to TamperEvent.InvalidSignature)
     }
 
     @Test
-    fun `read fires InvalidSignature when signature byte mutated`() = runTest {
-        val tamperEvents = mutableListOf<TamperEvent>()
-        val (storage, _, sigStore) = newStorage(onTamperDetected = { tamperEvents += it })
+    fun `readAll fires InvalidSignature when signature byte mutated`() = runTest {
+        val tamperEvents = mutableListOf<Pair<String, TamperEvent>>()
+        val (storage, _, sigStore) = newStorage(onTamperDetected = { key, e -> tamperEvents += key to e })
 
-        storage.write(sampleSnapshot)
-        val mutated = sigStore.last!!.copyOf()
+        storage.write(keyOne, sampleSnapshotOne)
+        val original = sigStore.lastFor(keyOne)!!
+        val mutated = original.copyOf()
         mutated[mutated.size - 1] = (mutated[mutated.size - 1].toInt() xor 0xff).toByte()
-        sigStore.last = mutated
+        sigStore.put(keyOne, mutated)
 
-        assertThat(storage.read()).isNull()
-        assertThat(tamperEvents).containsExactly(TamperEvent.InvalidSignature)
+        assertThat(storage.readAll()).isEmpty()
+        assertThat(tamperEvents).containsExactly(keyOne to TamperEvent.InvalidSignature)
     }
 
     @Test
-    fun `read fires UnsupportedVersion when blob declares version above MAX_SUPPORTED_VERSION`() = runTest {
-        val tamperEvents = mutableListOf<TamperEvent>()
-        val (storage, _, sigStore) = newStorage(onTamperDetected = { tamperEvents += it })
+    fun `cross-key signature swap fails verification`() = runTest {
+        // The strong guarantee from including the entitlement key in v2
+        // canonical bytes: a sig for keyOne can't validate a snapshot stored
+        // under keyTwo (and vice versa) even when both pairs share the same
+        // underlying snapshot fields.
+        val tamperEvents = mutableListOf<Pair<String, TamperEvent>>()
+        val (storage, _, sigStore) = newStorage(onTamperDetected = { key, e -> tamperEvents += key to e })
 
-        storage.write(sampleSnapshot)
-        val futureBlob = ByteBuffer.allocate(36).apply {
-            putInt(SnapshotCanonicalBytes.MAX_SUPPORTED_VERSION + 1)
-            put(sigStore.last!!.copyOfRange(4, 36))
-        }.array()
-        sigStore.last = futureBlob
+        // Identical snapshot bytes under both keys.
+        storage.write(keyOne, sampleSnapshotOne)
+        storage.write(keyTwo, sampleSnapshotOne)
 
-        assertThat(storage.read()).isNull()
+        // Swap the signature blobs.
+        val sigOne = sigStore.lastFor(keyOne)!!
+        val sigTwo = sigStore.lastFor(keyTwo)!!
+        sigStore.put(keyOne, sigTwo)
+        sigStore.put(keyTwo, sigOne)
+
+        assertThat(storage.readAll()).isEmpty()
         assertThat(tamperEvents).containsExactly(
-            TamperEvent.UnsupportedVersion(SnapshotCanonicalBytes.MAX_SUPPORTED_VERSION + 1),
+            keyOne to TamperEvent.InvalidSignature,
+            keyTwo to TamperEvent.InvalidSignature,
         )
     }
 
     @Test
-    fun `read fires UnsupportedVersion when blob declares version 0`() = runTest {
-        val tamperEvents = mutableListOf<TamperEvent>()
-        val (storage, _, sigStore) = newStorage(onTamperDetected = { tamperEvents += it })
+    fun `readAll fires UnsupportedVersion when blob declares version above MAX_SUPPORTED_VERSION`() = runTest {
+        val tamperEvents = mutableListOf<Pair<String, TamperEvent>>()
+        val (storage, _, sigStore) = newStorage(onTamperDetected = { key, e -> tamperEvents += key to e })
 
-        storage.write(sampleSnapshot)
-        val zeroVersionBlob = ByteBuffer.allocate(36).apply {
+        storage.write(keyOne, sampleSnapshotOne)
+        val originalBlob = sigStore.lastFor(keyOne)!!
+        val futureBlob = ByteBuffer.allocate(36).apply {
+            putInt(SnapshotCanonicalBytes.MAX_SUPPORTED_VERSION + 1)
+            put(originalBlob.copyOfRange(4, 36))
+        }.array()
+        sigStore.put(keyOne, futureBlob)
+
+        assertThat(storage.readAll()).isEmpty()
+        assertThat(tamperEvents).containsExactly(
+            keyOne to TamperEvent.UnsupportedVersion(SnapshotCanonicalBytes.MAX_SUPPORTED_VERSION + 1),
+        )
+    }
+
+    @Test
+    fun `readAll fires UnsupportedVersion when blob declares version 0`() = runTest {
+        val tamperEvents = mutableListOf<Pair<String, TamperEvent>>()
+        val (storage, _, sigStore) = newStorage(onTamperDetected = { key, e -> tamperEvents += key to e })
+
+        storage.write(keyOne, sampleSnapshotOne)
+        val zeroBlob = ByteBuffer.allocate(36).apply {
             putInt(0)
-            put(sigStore.last!!.copyOfRange(4, 36))
+            put(sigStore.lastFor(keyOne)!!.copyOfRange(4, 36))
         }.array()
-        sigStore.last = zeroVersionBlob
+        sigStore.put(keyOne, zeroBlob)
 
-        assertThat(storage.read()).isNull()
-        assertThat(tamperEvents).containsExactly(TamperEvent.UnsupportedVersion(0))
+        assertThat(storage.readAll()).isEmpty()
+        assertThat(tamperEvents).containsExactly(keyOne to TamperEvent.UnsupportedVersion(0))
     }
 
     @Test
-    fun `read fires UnsupportedVersion when blob declares negative version`() = runTest {
-        val tamperEvents = mutableListOf<TamperEvent>()
-        val (storage, _, sigStore) = newStorage(onTamperDetected = { tamperEvents += it })
+    fun `readAll fires UnsupportedVersion when blob declares negative version`() = runTest {
+        val tamperEvents = mutableListOf<Pair<String, TamperEvent>>()
+        val (storage, _, sigStore) = newStorage(onTamperDetected = { key, e -> tamperEvents += key to e })
 
-        storage.write(sampleSnapshot)
-        val negativeVersionBlob = ByteBuffer.allocate(36).apply {
+        storage.write(keyOne, sampleSnapshotOne)
+        val negativeBlob = ByteBuffer.allocate(36).apply {
             putInt(-1)
-            put(sigStore.last!!.copyOfRange(4, 36))
+            put(sigStore.lastFor(keyOne)!!.copyOfRange(4, 36))
         }.array()
-        sigStore.last = negativeVersionBlob
+        sigStore.put(keyOne, negativeBlob)
 
-        assertThat(storage.read()).isNull()
-        assertThat(tamperEvents).containsExactly(TamperEvent.UnsupportedVersion(-1))
+        assertThat(storage.readAll()).isEmpty()
+        assertThat(tamperEvents).containsExactly(keyOne to TamperEvent.UnsupportedVersion(-1))
     }
 
     @Test
-    fun `read fires InvalidSignature when blob is truncated below expected size`() = runTest {
-        val tamperEvents = mutableListOf<TamperEvent>()
-        val (storage, _, sigStore) = newStorage(onTamperDetected = { tamperEvents += it })
+    fun `readAll fires InvalidSignature when blob is truncated below expected size`() = runTest {
+        val tamperEvents = mutableListOf<Pair<String, TamperEvent>>()
+        val (storage, _, sigStore) = newStorage(onTamperDetected = { key, e -> tamperEvents += key to e })
 
-        storage.write(sampleSnapshot)
-        sigStore.last = sigStore.last!!.copyOfRange(0, 10)
+        storage.write(keyOne, sampleSnapshotOne)
+        sigStore.put(keyOne, sigStore.lastFor(keyOne)!!.copyOfRange(0, 10))
 
-        assertThat(storage.read()).isNull()
-        assertThat(tamperEvents).containsExactly(TamperEvent.InvalidSignature)
+        assertThat(storage.readAll()).isEmpty()
+        assertThat(tamperEvents).containsExactly(keyOne to TamperEvent.InvalidSignature)
     }
 
     @Test
-    fun `read fires InvalidSignature when blob has trailing bytes beyond expected size`() = runTest {
-        val tamperEvents = mutableListOf<TamperEvent>()
-        val (storage, _, sigStore) = newStorage(onTamperDetected = { tamperEvents += it })
+    fun `readAll fires InvalidSignature when blob has trailing bytes beyond expected size`() = runTest {
+        val tamperEvents = mutableListOf<Pair<String, TamperEvent>>()
+        val (storage, _, sigStore) = newStorage(onTamperDetected = { key, e -> tamperEvents += key to e })
 
-        storage.write(sampleSnapshot)
-        sigStore.last = sigStore.last!! + ByteArray(4) { 0x42 }
+        storage.write(keyOne, sampleSnapshotOne)
+        sigStore.put(keyOne, sigStore.lastFor(keyOne)!! + ByteArray(4) { 0x42 })
 
-        assertThat(storage.read()).isNull()
-        assertThat(tamperEvents).containsExactly(TamperEvent.InvalidSignature)
+        assertThat(storage.readAll()).isEmpty()
+        assertThat(tamperEvents).containsExactly(keyOne to TamperEvent.InvalidSignature)
+    }
+
+    @Test
+    fun `one key's tamper does not affect other verified keys`() = runTest {
+        val tamperEvents = mutableListOf<Pair<String, TamperEvent>>()
+        val (storage, delegate, _) = newStorage(onTamperDetected = { key, e -> tamperEvents += key to e })
+
+        storage.write(keyOne, sampleSnapshotOne)
+        storage.write(keyTwo, sampleSnapshotTwo)
+        delegate.put(keyOne, sampleSnapshotOne.copy(isEntitled = false))   // mutate keyOne's snapshot
+
+        val verified = storage.readAll()
+        assertThat(verified).containsExactly(keyTwo, sampleSnapshotTwo)
+        assertThat(tamperEvents).containsExactly(keyOne to TamperEvent.InvalidSignature)
     }
 
     @Test
     fun `write does not persist snapshot when keyProvider sign throws`() = runTest {
-        val delegate = InMemoryStorage()
+        val delegate = InMemoryStorage<String>()
         val sigStore = InMemorySignatureStore()
         val storage = SignedEntitlementStorage(
-            delegate, keyProvider = ThrowingKeyProvider, signatureStore = sigStore,
+            delegate = delegate,
+            keyProvider = ThrowingKeyProvider,
+            signatureStore = sigStore,
+            keyToStorageId = { it },
         )
 
         try {
-            storage.write(sampleSnapshot)
+            storage.write(keyOne, sampleSnapshotOne)
             error("Expected IllegalStateException from sign()")
         } catch (e: IllegalStateException) {
             // expected
         }
 
-        assertThat(delegate.lastWritten).isNull()
-        assertThat(sigStore.last).isNull()
+        assertThat(delegate.last(keyOne)).isNull()
+        assertThat(sigStore.lastFor(keyOne)).isNull()
     }
 
     @Test
     fun `write throws when keyProvider produces wrong-sized hmac`() = runTest {
         val storage = SignedEntitlementStorage(
-            delegate = InMemoryStorage(),
+            delegate = InMemoryStorage<String>(),
             keyProvider = object : HmacKeyProvider {
                 override suspend fun sign(data: ByteArray): ByteArray = ByteArray(16) { 0x01 }
             },
             signatureStore = InMemorySignatureStore(),
+            keyToStorageId = { it },
         )
 
         try {
-            storage.write(sampleSnapshot)
+            storage.write(keyOne, sampleSnapshotOne)
             error("Expected IllegalArgumentException")
         } catch (e: IllegalArgumentException) {
             assertThat(e.message).contains("16-byte")
@@ -188,80 +252,80 @@ class SignedEntitlementStorageTest {
 
     @Test
     fun `migrateUnsignedSnapshot returns false when delegate has no snapshot`() = runTest {
-        val delegate = InMemoryStorage()
+        val delegate = InMemoryStorage<String>()
         val sigStore = InMemorySignatureStore()
         val keyProvider = FixedKeyHmacProvider(KEY_BYTES)
 
-        val migrated = SignedEntitlementStorage.migrateUnsignedSnapshot(delegate, keyProvider, sigStore)
+        val migrated = SignedEntitlementStorage.migrateUnsignedSnapshot(
+            entitlementKey = keyOne,
+            entitlementCacheKey = keyOne,
+            delegate = delegate,
+            keyProvider = keyProvider,
+            signatureStore = sigStore,
+        )
 
         assertThat(migrated).isFalse()
-        assertThat(sigStore.last).isNull()
+        assertThat(sigStore.lastFor(keyOne)).isNull()
     }
 
     @Test
     fun `migrateUnsignedSnapshot signs existing snapshot and subsequent reads succeed without callback`() = runTest {
-        val delegate = InMemoryStorage().also { it.lastWritten = sampleSnapshot }
+        val delegate = InMemoryStorage<String>().also { it.put(keyOne, sampleSnapshotOne) }
         val sigStore = InMemorySignatureStore()
         val keyProvider = FixedKeyHmacProvider(KEY_BYTES)
-        val tamperEvents = mutableListOf<TamperEvent>()
+        val tamperEvents = mutableListOf<Pair<String, TamperEvent>>()
 
-        val migrated = SignedEntitlementStorage.migrateUnsignedSnapshot(delegate, keyProvider, sigStore)
+        val migrated = SignedEntitlementStorage.migrateUnsignedSnapshot(
+            entitlementKey = keyOne,
+            entitlementCacheKey = keyOne,
+            delegate = delegate,
+            keyProvider = keyProvider,
+            signatureStore = sigStore,
+        )
         assertThat(migrated).isTrue()
-        assertThat(sigStore.last).isNotNull()
+        assertThat(sigStore.lastFor(keyOne)).isNotNull()
 
         val storage = SignedEntitlementStorage(
-            delegate, keyProvider, sigStore,
-            onTamperDetected = { tamperEvents += it },
+            delegate = delegate,
+            keyProvider = keyProvider,
+            signatureStore = sigStore,
+            keyToStorageId = { it },
+            onTamperDetected = { key, e -> tamperEvents += key to e },
         )
-        assertThat(storage.read()).isEqualTo(sampleSnapshot)
+        assertThat(storage.readAll()).containsExactly(keyOne, sampleSnapshotOne)
         assertThat(tamperEvents).isEmpty()
-    }
-
-    @Test
-    fun `migrateUnsignedSnapshot does not read delegate when signature already present`() = runTest {
-        val keyProvider = FixedKeyHmacProvider(KEY_BYTES)
-        val sigStore = InMemorySignatureStore().also { it.last = ByteArray(36) }
-        val delegate = object : EntitlementStorage {
-            var readCalls = 0
-            override suspend fun read(): EntitlementSnapshot? {
-                readCalls++; return null
-            }
-            override suspend fun write(snapshot: EntitlementSnapshot) = error("unexpected")
-        }
-
-        val migrated = SignedEntitlementStorage.migrateUnsignedSnapshot(delegate, keyProvider, sigStore)
-
-        assertThat(migrated).isFalse()
-        assertThat(delegate.readCalls).isEqualTo(0)
     }
 
     @Test
     fun `migrateUnsignedSnapshot is a no-op when signature already present`() = runTest {
         val (storage, _, sigStore) = newStorage()
-        storage.write(sampleSnapshot)
-        val firstBlob = sigStore.last!!.copyOf()
+        storage.write(keyOne, sampleSnapshotOne)
+        val firstBlob = sigStore.lastFor(keyOne)!!.copyOf()
 
         val migrated = SignedEntitlementStorage.migrateUnsignedSnapshot(
+            entitlementKey = keyOne,
+            entitlementCacheKey = keyOne,
             delegate = storage,
             keyProvider = FixedKeyHmacProvider(KEY_BYTES),
             signatureStore = sigStore,
         )
 
         assertThat(migrated).isFalse()
-        assertThat(sigStore.last).isEqualTo(firstBlob)
+        assertThat(sigStore.lastFor(keyOne)).isEqualTo(firstBlob)
     }
 
     // -- helpers -----------------------------------------------------------
 
     private fun newStorage(
-        onTamperDetected: (TamperEvent) -> Unit = {},
-    ): Triple<SignedEntitlementStorage, InMemoryStorage, InMemorySignatureStore> {
-        val delegate = InMemoryStorage()
+        onTamperDetected: (String, TamperEvent) -> Unit = { _, _ -> },
+    ): Triple<SignedEntitlementStorage<String>, InMemoryStorage<String>, InMemorySignatureStore> {
+        val delegate = InMemoryStorage<String>()
         val sigStore = InMemorySignatureStore()
         val storage = SignedEntitlementStorage(
             delegate = delegate,
             keyProvider = FixedKeyHmacProvider(KEY_BYTES),
             signatureStore = sigStore,
+            keyToStorageId = { it },
             onTamperDetected = onTamperDetected,
         )
         return Triple(storage, delegate, sigStore)
@@ -272,23 +336,39 @@ class SignedEntitlementStorageTest {
     }
 }
 
-private class InMemoryStorage : EntitlementStorage {
-    var lastWritten: EntitlementSnapshot? = null
+private class InMemoryStorage<K : Any> : EntitlementStorage<K> {
+    private val store: MutableMap<K, EntitlementSnapshot> = HashMap()
 
-    override suspend fun read(): EntitlementSnapshot? = lastWritten
+    fun last(key: K): EntitlementSnapshot? = store[key]
 
-    override suspend fun write(snapshot: EntitlementSnapshot) {
-        lastWritten = snapshot
+    fun put(key: K, snapshot: EntitlementSnapshot) {
+        store[key] = snapshot
+    }
+
+    override suspend fun readAll(): Map<K, EntitlementSnapshot> = HashMap(store)
+
+    override suspend fun write(key: K, snapshot: EntitlementSnapshot) {
+        store[key] = snapshot
     }
 }
 
 private class InMemorySignatureStore : SignatureStore {
-    var last: ByteArray? = null
+    private val store: MutableMap<String, ByteArray> = HashMap()
 
-    override suspend fun readSignature(): ByteArray? = last
+    fun lastFor(entitlementKey: String): ByteArray? = store[entitlementKey]
 
-    override suspend fun writeSignature(signature: ByteArray) {
-        last = signature
+    fun put(entitlementKey: String, signature: ByteArray) {
+        store[entitlementKey] = signature
+    }
+
+    override suspend fun readSignature(entitlementKey: String): ByteArray? = store[entitlementKey]
+
+    override suspend fun writeSignature(entitlementKey: String, signature: ByteArray) {
+        store[entitlementKey] = signature
+    }
+
+    override suspend fun clearSignature(entitlementKey: String) {
+        store.remove(entitlementKey)
     }
 }
 

--- a/billing/src/test/kotlin/com/kanetik/billing/entitlement/signed/SnapshotCanonicalBytesTest.kt
+++ b/billing/src/test/kotlin/com/kanetik/billing/entitlement/signed/SnapshotCanonicalBytesTest.kt
@@ -13,70 +13,158 @@ class SnapshotCanonicalBytesTest {
         purchaseToken = "tok-baseline",
     )
 
+    private val sampleKey = "entitlement_one"
+
+    // -- v1 (legacy, no entitlement key) ----------------------------------
+
     @Test
-    fun `encode is deterministic for the same snapshot and version`() {
-        val a = SnapshotCanonicalBytes.encode(baseline, 1)
-        val b = SnapshotCanonicalBytes.encode(baseline, 1)
+    fun `v1 encode is deterministic for the same snapshot`() {
+        val a = SnapshotCanonicalBytes.encode(baseline, sampleKey, 1)
+        val b = SnapshotCanonicalBytes.encode(baseline, sampleKey, 1)
         assertThat(a).isEqualTo(b)
     }
 
     @Test
-    fun `encode starts with the version int in big-endian`() {
-        val bytes = SnapshotCanonicalBytes.encode(baseline, 1)
+    fun `v1 encode ignores entitlement key (legacy single-entitlement format)`() {
+        val a = SnapshotCanonicalBytes.encode(baseline, "one", 1)
+        val b = SnapshotCanonicalBytes.encode(baseline, "two", 1)
+        // v1 was written by the single-entitlement library and does NOT
+        // include the entitlement key in the canonical bytes. The same
+        // snapshot bytes are produced regardless of the entitlement key —
+        // which is what lets v0.1.x v1 sigs continue to verify on upgrade.
+        assertThat(a).isEqualTo(b)
+    }
+
+    @Test
+    fun `v1 encode starts with the version int in big-endian`() {
+        val bytes = SnapshotCanonicalBytes.encode(baseline, sampleKey, 1)
         val parsedVersion = ByteBuffer.wrap(bytes, 0, 4).int
         assertThat(parsedVersion).isEqualTo(1)
     }
 
     @Test
-    fun `different isEntitled produces different bytes`() {
-        val truthy = SnapshotCanonicalBytes.encode(baseline, 1)
-        val falsy = SnapshotCanonicalBytes.encode(baseline.copy(isEntitled = false), 1)
+    fun `v1 different isEntitled produces different bytes`() {
+        val truthy = SnapshotCanonicalBytes.encode(baseline, sampleKey, 1)
+        val falsy = SnapshotCanonicalBytes.encode(baseline.copy(isEntitled = false), sampleKey, 1)
         assertThat(truthy).isNotEqualTo(falsy)
     }
 
     @Test
-    fun `different confirmedAtMs produces different bytes`() {
-        val original = SnapshotCanonicalBytes.encode(baseline, 1)
-        val shifted = SnapshotCanonicalBytes.encode(baseline.copy(confirmedAtMs = baseline.confirmedAtMs + 1), 1)
+    fun `v1 different confirmedAtMs produces different bytes`() {
+        val original = SnapshotCanonicalBytes.encode(baseline, sampleKey, 1)
+        val shifted = SnapshotCanonicalBytes.encode(baseline.copy(confirmedAtMs = baseline.confirmedAtMs + 1), sampleKey, 1)
         assertThat(original).isNotEqualTo(shifted)
     }
 
     @Test
-    fun `different purchaseToken produces different bytes`() {
-        val original = SnapshotCanonicalBytes.encode(baseline, 1)
-        val swapped = SnapshotCanonicalBytes.encode(baseline.copy(purchaseToken = "tok-other"), 1)
+    fun `v1 different purchaseToken produces different bytes`() {
+        val original = SnapshotCanonicalBytes.encode(baseline, sampleKey, 1)
+        val swapped = SnapshotCanonicalBytes.encode(baseline.copy(purchaseToken = "tok-other"), sampleKey, 1)
         assertThat(original).isNotEqualTo(swapped)
     }
 
     @Test
-    fun `null and empty purchaseToken produce different bytes`() {
-        val nullToken = SnapshotCanonicalBytes.encode(baseline.copy(purchaseToken = null), 1)
-        val emptyToken = SnapshotCanonicalBytes.encode(baseline.copy(purchaseToken = ""), 1)
+    fun `v1 null and empty purchaseToken produce different bytes`() {
+        val nullToken = SnapshotCanonicalBytes.encode(baseline.copy(purchaseToken = null), sampleKey, 1)
+        val emptyToken = SnapshotCanonicalBytes.encode(baseline.copy(purchaseToken = ""), sampleKey, 1)
         assertThat(nullToken).isNotEqualTo(emptyToken)
     }
 
     @Test
-    fun `null token sets token_len field to -1`() {
-        val bytes = SnapshotCanonicalBytes.encode(baseline.copy(purchaseToken = null), 1)
-        // version(4) + isEntitled(1) + confirmedAtMs(8) = 13, then token_len(4) at offset 13
+    fun `v1 null token sets token_len field to -1`() {
+        val bytes = SnapshotCanonicalBytes.encode(baseline.copy(purchaseToken = null), sampleKey, 1)
+        // v1 layout: version(4) + isEntitled(1) + confirmedAtMs(8) = 13, then token_len(4) at offset 13.
         val tokenLen = ByteBuffer.wrap(bytes, 13, 4).int
         assertThat(tokenLen).isEqualTo(-1)
     }
 
     @Test
-    fun `empty token sets token_len field to 0`() {
-        val bytes = SnapshotCanonicalBytes.encode(baseline.copy(purchaseToken = ""), 1)
+    fun `v1 empty token sets token_len field to 0`() {
+        val bytes = SnapshotCanonicalBytes.encode(baseline.copy(purchaseToken = ""), sampleKey, 1)
         val tokenLen = ByteBuffer.wrap(bytes, 13, 4).int
         assertThat(tokenLen).isEqualTo(0)
     }
 
+    // -- v2 (current, includes entitlement key) ---------------------------
+
+    @Test
+    fun `v2 encode is deterministic for the same snapshot and key`() {
+        val a = SnapshotCanonicalBytes.encode(baseline, sampleKey, 2)
+        val b = SnapshotCanonicalBytes.encode(baseline, sampleKey, 2)
+        assertThat(a).isEqualTo(b)
+    }
+
+    @Test
+    fun `v2 different entitlement keys produce different bytes (cross-key swap detection)`() {
+        val a = SnapshotCanonicalBytes.encode(baseline, "one", 2)
+        val b = SnapshotCanonicalBytes.encode(baseline, "two", 2)
+        assertThat(a).isNotEqualTo(b)
+    }
+
+    @Test
+    fun `v2 encode starts with the version int in big-endian`() {
+        val bytes = SnapshotCanonicalBytes.encode(baseline, sampleKey, 2)
+        assertThat(ByteBuffer.wrap(bytes, 0, 4).int).isEqualTo(2)
+    }
+
+    @Test
+    fun `v2 different isEntitled produces different bytes`() {
+        val truthy = SnapshotCanonicalBytes.encode(baseline, sampleKey, 2)
+        val falsy = SnapshotCanonicalBytes.encode(baseline.copy(isEntitled = false), sampleKey, 2)
+        assertThat(truthy).isNotEqualTo(falsy)
+    }
+
+    @Test
+    fun `v2 different confirmedAtMs produces different bytes`() {
+        val original = SnapshotCanonicalBytes.encode(baseline, sampleKey, 2)
+        val shifted = SnapshotCanonicalBytes.encode(baseline.copy(confirmedAtMs = baseline.confirmedAtMs + 1), sampleKey, 2)
+        assertThat(original).isNotEqualTo(shifted)
+    }
+
+    @Test
+    fun `v2 different purchaseToken produces different bytes`() {
+        val original = SnapshotCanonicalBytes.encode(baseline, sampleKey, 2)
+        val swapped = SnapshotCanonicalBytes.encode(baseline.copy(purchaseToken = "tok-other"), sampleKey, 2)
+        assertThat(original).isNotEqualTo(swapped)
+    }
+
+    @Test
+    fun `v2 includes key bytes in the canonical encoding`() {
+        val bytes = SnapshotCanonicalBytes.encode(baseline, "abc", 2)
+        // v2 layout: version(4) + key_len(4) + key_utf8(key_len) + ...
+        val keyLen = ByteBuffer.wrap(bytes, 4, 4).int
+        assertThat(keyLen).isEqualTo(3)
+        val keyBytes = bytes.copyOfRange(8, 8 + keyLen)
+        assertThat(String(keyBytes, Charsets.UTF_8)).isEqualTo("abc")
+    }
+
+    @Test
+    fun `v2 supports empty key`() {
+        // K = Unit + keyToStorageId = { "" } collapses to an empty key. Must
+        // still produce deterministic distinct-from-other-bytes output.
+        val emptyKey = SnapshotCanonicalBytes.encode(baseline, "", 2)
+        val nonEmpty = SnapshotCanonicalBytes.encode(baseline, "x", 2)
+        assertThat(emptyKey).isNotEqualTo(nonEmpty)
+
+        // key_len = 0 immediately followed by the rest of the v2 fields.
+        val keyLen = ByteBuffer.wrap(emptyKey, 4, 4).int
+        assertThat(keyLen).isEqualTo(0)
+    }
+
+    // -- version validation ----------------------------------------------
+
     @Test
     fun `unknown version throws IllegalArgumentException`() {
         try {
-            SnapshotCanonicalBytes.encode(baseline, 999)
+            SnapshotCanonicalBytes.encode(baseline, sampleKey, 999)
             error("Expected IllegalArgumentException")
         } catch (e: IllegalArgumentException) {
             assertThat(e.message).contains("999")
         }
+    }
+
+    @Test
+    fun `CURRENT_VERSION is v2`() {
+        assertThat(SnapshotCanonicalBytes.CURRENT_VERSION).isEqualTo(2)
     }
 }

--- a/docs/guides/consumables.md
+++ b/docs/guides/consumables.md
@@ -1,0 +1,126 @@
+# Consumables: wallet ledger pattern
+
+Consumable products are different from non-consumable unlocks in a way that matters for how you track them:
+
+- A **non-consumable unlock** ("Pro toolkit", "ad removal") is one purchase that grants permanent access to a feature. The right state machine is `Granted | InGrace | Revoked` — exactly what [`EntitlementCache`](entitlement-cache.md) is built for.
+- A **consumable** ("100 coins", "5 gallons of fuel") is a one-shot credit. Each successful purchase adds N units to a wallet; gameplay (or whatever) spends them down; when the wallet is empty, the user buys again — same SKU, fresh purchase, fresh token. There's no "is the user entitled?" state — there's only a running balance.
+
+`EntitlementCache` deliberately does **not** track wallet balances. This page is the pattern for the cache-on-the-side that does.
+
+## What the library handles
+
+The library wrapper takes consumable purchases all the way through Play's acknowledge / consume protocol the same way it handles non-consumables:
+
+- `handlePurchase(purchase, consume = true)` — calls Play's `consumeAsync` (which doubles as the acknowledgement for consumables; Play doesn't separate the two for this product type). Returns `Success` when the consume call landed.
+- Recovery sweep — on every successful connection, any unacknowledged consumable purchase that the user paid for but the app never finished consuming gets re-emitted as `OwnedPurchases.Recovered`. Hand it back to `handlePurchase(consume = true)` and grant the wallet units the same way you would for a `Live` purchase. **This is the reason a wallet ledger is your responsibility — only the consumer knows how many units a purchase grants.**
+
+## What you handle: the wallet
+
+Apps that sell consumables maintain a wallet (a `Map<WalletId, Int>`, a single `Long` for one-currency apps, etc.) outside the cache. The wallet:
+
+- Increments on `HandlePurchaseResult.Success` from a consumable purchase, by `purchase.quantity * unitsPerSku[productId]`.
+- Decrements when gameplay spends units.
+- Persists to your own storage. The library has nothing to say about this — pick DataStore, Room, encrypted prefs, whatever fits.
+
+The library's job ends at "I successfully consumed this purchase with Play; safe for you to grant now"; the wallet's job is everything else.
+
+## Minimal sketch
+
+```kotlin
+class CoinWallet(private val storage: WalletStorage) {
+    private val _balance = MutableStateFlow(storage.read())
+    val balance: StateFlow<Int> = _balance.asStateFlow()
+
+    suspend fun grant(units: Int) {
+        val next = _balance.value + units
+        storage.write(next)
+        _balance.value = next
+    }
+
+    suspend fun spend(units: Int): Boolean {
+        if (_balance.value < units) return false
+        val next = _balance.value - units
+        storage.write(next)
+        _balance.value = next
+        return true
+    }
+}
+
+class ShopViewModel(
+    private val billing: BillingRepository,
+    private val wallet: CoinWallet,
+) : ViewModel() {
+    private val unitsPerSku = mapOf(
+        "coins_pack_50"   to 50,
+        "coins_pack_500"  to 500,
+        "coins_pack_5000" to 5_000,
+    )
+
+    init {
+        viewModelScope.launch {
+            billing.observePurchaseUpdates().collect { event ->
+                when (event) {
+                    is OwnedPurchases.Live -> event.purchases.forEach { grantOrSkip(it) }
+                    is OwnedPurchases.Recovered -> event.purchases.forEach { grantOrSkip(it) }
+                    else -> { /* not our concern here */ }
+                }
+            }
+        }
+    }
+
+    private suspend fun grantOrSkip(purchase: Purchase) {
+        // Find the wallet SKU on this purchase. Returning early on a non-match
+        // keeps the wallet branch separate from any EntitlementCache branch
+        // your app also runs against the same stream.
+        val unitsPer = purchase.products
+            .firstNotNullOfOrNull { unitsPerSku[it] } ?: return
+
+        when (val r = billing.handlePurchase(purchase, consume = true)) {
+            HandlePurchaseResult.Success ->
+                wallet.grant(units = unitsPer * purchase.quantity)
+            HandlePurchaseResult.AlreadyAcknowledged -> {
+                // Unreachable for consume = true. Consumables aren't acked
+                // (they're consumed); short-circuit only fires on the
+                // consume = false path. Branch present for exhaustiveness.
+            }
+            HandlePurchaseResult.NotPurchased -> {
+                // Pending — wait for the matching Live update that arrives
+                // when payment confirms. The library re-delivers it.
+            }
+            HandlePurchaseResult.NotOwned -> {
+                // Stale snapshot — Play says this purchase isn't owned. Defer
+                // to your reconciliation logic; do not credit the wallet.
+            }
+            is HandlePurchaseResult.Failure -> {
+                // Don't grant. The recovery sweep re-emits the unacknowledged
+                // purchase on the next connect for retry.
+            }
+        }
+    }
+}
+```
+
+Three things to call out about this shape:
+
+- **`purchase.quantity` matters.** Read it on every grant. Defaults to `1` so single-unit code stays correct, but ignoring it on a multi-quantity purchase silently under-credits. See [Multi-quantity purchases](multi-quantity.md).
+- **Only grant on `Success`.** Crediting on `Failure` and "fixing it later" leaves you with phantom currency the user didn't really pay for; the [Purchase recovery](purchase-recovery.md) sweep retries acked-less purchases on the next connect, so transient failures resolve themselves.
+- **Idempotency.** Each successful `consumeAsync` produces one `Success`. Multiple `Recovered` snapshots can carry the same purchase token before Play marks it acknowledged, but the library's internal acked-token filter (see [Purchase recovery](purchase-recovery.md)) prevents re-delivery once the consume lands. If you want belt-and-suspenders, store the last-credited token in your wallet and skip duplicates explicitly.
+
+## Mixing wallets with `EntitlementCache`
+
+The two coexist on the same `observePurchaseUpdates()` stream:
+
+- Wallet path: branch on consumable product IDs; call `handlePurchase(consume = true)`; credit the wallet on `Success`.
+- Cache path: pass a `productKeySelector` that returns the entitlement key only for non-consumable SKUs and `null` otherwise. The cache then ignores consumable purchases — they don't grant any tracked entitlement.
+
+The `productKeySelector` example in [`EntitlementCache`](entitlement-cache.md) shows this split — consumable currency packs `return null` so they never end up in the cache's state map, while non-consumable unlocks map to a key.
+
+## What about server-side?
+
+The library has nothing to do with server-side wallet management — that's deliberately a separate concern. If your app awards wallet credits on the server (you have a backend and want it to be the source of truth):
+
+- Have the server consume the Purchase via `Purchases.products:consume` on the Play Developer API.
+- Skip `handlePurchase(consume = true)` on the client for that SKU.
+- Let your server-issued FCM (or whatever) push the updated balance into the client wallet.
+
+The two paths shouldn't both consume the same purchase — Play accepts the first consume and `ITEM_NOT_OWNED`s the second, which the library surfaces as `HandlePurchaseResult.NotOwned`. Either pick client-driven consume (this guide) or server-driven consume (your backend's call) per SKU; don't mix on the same one.

--- a/docs/guides/entitlement-cache.md
+++ b/docs/guides/entitlement-cache.md
@@ -2,13 +2,25 @@
 
 Once your code can answer "did the user buy this" in the moment, three follow-up questions usually land within a few weeks of shipping:
 
-- How do I render premium UI on cold start, *before* the first PBL round-trip lands? (Otherwise paying users see the free-tier UI flicker every launch.)
+- How do I render gated UI on cold start, *before* the first PBL round-trip lands? (Otherwise paying users see the free-tier UI flicker every launch.)
 - What do I do when Play is unreachable for an hour or two: flip every paid user back to the free tier, or wait it out?
 - How do I keep my entitlement verdict consistent across process death, configuration changes, and app updates?
 
-PBL doesn't answer any of these. They're consumer concerns built on top of the protocol, which is why most apps end up reinventing the same `(isEntitled, lastConfirmedTimestamp, source)` state machine: take the raw `PurchaseEvent` stream, decide which purchases grant a given entitlement, persist the verdict so premium UI can render before the first network round-trip, and add a grace window so a transient outage doesn't immediately yank features from a paid user. `EntitlementCache` (in `com.kanetik.billing.entitlement`) is that state machine, opt-in.
+PBL doesn't answer any of these. They're consumer concerns built on top of the protocol, which is why most apps end up reinventing the same `(isEntitled, lastConfirmedTimestamp, source) per entitlement` state machine: take the raw `PurchaseEvent` stream, decide which purchases grant which entitlement, persist the verdict so gated UI can render before the first network round-trip, and add a grace window so a transient outage doesn't immediately yank features from a paid user. `EntitlementCache<K>` (in `com.kanetik.billing.entitlement`) is that state machine, opt-in.
 
 It listens to `observePurchaseUpdates()`, so it benefits from the auto-recovery sweep. See [Purchase recovery](purchase-recovery.md) for what `OwnedPurchases.Live` vs `OwnedPurchases.Recovered` actually mean and why you can't just write the callback's `purchases` list to your storage and call it done.
+
+## Choosing K
+
+`K` is whatever type your app uses to discriminate entitlements:
+
+- **One non-consumable unlock** (e.g. "ad removal"): `K = Unit`. The state map collapses to `{Unit -> ...}` and `stateFor(Unit)` gives you a single `Flow<EntitlementState>`.
+- **A few non-consumable upgrades** (e.g. a game with a "Pro toolkit" + an "Expansion pack"): `K = String` (product IDs) or `enum class Entitlement { PRO_TOOLKIT, EXPANSION }`.
+- **Consumables** (coins, gems, fuel): the cache is **not** the right shape — see the [Consumables ledger guide](consumables.md). Your `productKeySelector` should return `null` for consumable SKUs so they bypass the cache entirely.
+
+Consumables and entitlements often coexist in the same app; the `productKeySelector` is the seam where you tell the cache "ignore these, they're wallet credits."
+
+## Single-entitlement wiring
 
 ```kotlin
 import com.kanetik.billing.entitlement.EntitlementCache
@@ -18,9 +30,9 @@ import com.kanetik.billing.entitlement.EntitlementStorage
 import com.kanetik.billing.entitlement.GracePolicy
 import java.util.concurrent.TimeUnit
 
-class PremiumViewModel(
+class AdRemovalViewModel(
     billing: BillingRepository,
-    storage: EntitlementStorage, // your impl — see below
+    storage: EntitlementStorage<Unit>, // your impl — see below
 ) : ViewModel() {
 
     private val cache = EntitlementCache(
@@ -30,103 +42,163 @@ class PremiumViewModel(
             billingUnavailableMs = TimeUnit.HOURS.toMillis(72),
             transientFailureMs   = TimeUnit.HOURS.toMillis(6),
         ),
-        productPredicate = { it.products.contains("premium_lifetime") },
+        productKeySelector = { purchase ->
+            if (purchase.products.contains("ad_removal")) Unit else null
+        },
     )
 
     init {
         // start() is suspend so hydration completes before it returns —
         // the first read of cache.state.value reflects the persisted
-        // snapshot, not the default Revoked. Launch it from viewModelScope
+        // snapshot, not the default empty map. Launch it from viewModelScope
         // so init isn't blocked.
         viewModelScope.launch { cache.start(viewModelScope) }
     }
 
-    val isPremium: StateFlow<Boolean> = cache.state
-        .map { it !is EntitlementState.Revoked }
+    val adsRemoved: StateFlow<Boolean> = cache.stateFor(Unit)
+        .map { it is EntitlementState.Granted || it is EntitlementState.InGrace }
         .stateIn(viewModelScope, SharingStarted.Eagerly, false)
 }
 ```
 
-The cache exposes a `StateFlow<EntitlementState>` with three terminal states:
+## Multi-entitlement wiring
 
-- `Granted` — confirmed entitlement; show premium UI.
+```kotlin
+enum class GameEntitlement { PRO_TOOLKIT, EXPANSION_PACK }
+
+class ShopViewModel(
+    billing: BillingRepository,
+    storage: EntitlementStorage<GameEntitlement>,
+) : ViewModel() {
+
+    private val cache = EntitlementCache(
+        purchasesUpdates = billing.observePurchaseUpdates(),
+        storage = storage,
+        gracePolicy = GracePolicy(
+            billingUnavailableMs = TimeUnit.HOURS.toMillis(72),
+            transientFailureMs   = TimeUnit.HOURS.toMillis(6),
+        ),
+        productKeySelector = { purchase ->
+            when {
+                "pro_toolkit"    in purchase.products -> GameEntitlement.PRO_TOOLKIT
+                "expansion_pack" in purchase.products -> GameEntitlement.EXPANSION_PACK
+                else -> null   // consumable currency packs bypass the cache; see the consumables guide
+            }
+        },
+    )
+
+    init { viewModelScope.launch { cache.start(viewModelScope) } }
+
+    val hasProToolkit: Flow<Boolean> = cache.stateFor(GameEntitlement.PRO_TOOLKIT)
+        .map { it is EntitlementState.Granted || it is EntitlementState.InGrace }
+
+    val hasExpansion: Flow<Boolean> = cache.stateFor(GameEntitlement.EXPANSION_PACK)
+        .map { it is EntitlementState.Granted || it is EntitlementState.InGrace }
+}
+```
+
+## State
+
+The cache exposes a `StateFlow<Map<K, EntitlementState>>`. Keys absent from the map are implicitly `EntitlementState.Revoked` (the cache hasn't observed a granting purchase for them). Each per-key value is one of three terminal states:
+
+- `Granted` — confirmed entitlement; show the gated UI / unlock the feature.
 - `InGrace(expiresAtMs, reason)` — recently confirmed, then a `FlowOutcome.Failure` arrived. Treat as entitled until `expiresAtMs`; after that the cache transitions to `Revoked`. Reason is one of `BillingUnavailable` (Play Services missing, account ineligible, region restriction) or `TransientFailure` (network error, service disconnect, generic billing error).
-- `Revoked` — no entitlement; hide premium UI.
+- `Revoked` — no entitlement; hide the gated UI.
 
-Grace expiry is re-evaluated on every emission and on a periodic tick, so an extended outage correctly transitions `InGrace → Revoked` even when no further updates arrive in between.
+`stateFor(key: K)` returns a `Flow<EntitlementState>` that surfaces absent keys as `Revoked` and is `distinctUntilChanged()` against unchanged values — usually what you want for UI binding.
+
+Grace expiry is re-evaluated on every emission and on a periodic tick, per key, so an extended outage correctly transitions `InGrace → Revoked` even when no further updates arrive in between.
 
 ## When to use it
 
-Use `EntitlementCache` when you want a simple `is the user entitled right now?` flow off the side of your existing `observePurchaseUpdates()` integration. The cache is purely observational; it does **not** call `handlePurchase` for you. Acknowledge / consume + entitlement grant remain your collector's job. The cache just tracks the resulting confirmed observation.
+Use `EntitlementCache` when you want a simple `is the user entitled to X right now?` flow off the side of your existing `observePurchaseUpdates()` integration. The cache is purely observational; it does **not** call `handlePurchase` for you. Acknowledge / consume + entitlement grant remain your collector's job. The cache just tracks the resulting confirmed observation.
 
-Skip it if you have your own state machine you're already happy with, or if you need behavior the cache doesn't cover (subscription tier comparison, server-side reconciliation as the source of truth, multi-entitlement dispatch). Write a thin custom layer for those.
+Skip it if you have your own state machine you're already happy with, or if you need behavior the cache doesn't cover (subscription tier comparison, server-side reconciliation as the source of truth, dynamically-added entitlements). Write a thin custom layer for those.
 
 The cache reacts to four event paths:
 
-- `OwnedPurchases.Live` and `OwnedPurchases.Recovered` are **grant-only**. A match against the cache's `productPredicate` transitions to `Granted` and persists the snapshot. A *non-match* on either does **not** revoke. `Live` can carry `UNSPECIFIED_STATE` entries or products unrelated to the predicate, and `Recovered` only emits the unacknowledged subset (an already-acked entitlement won't appear in it). Treating either as authoritative for revocation would falsely revoke users with already-acknowledged purchases.
-- `FlowOutcome.Failure` triggers `InGrace` (or transitions straight to `Revoked` if the policy window is zero or has already elapsed since the last confirmation).
-- `PurchaseRevoked` matched against `lastConfirmedSnapshot.purchaseToken` transitions to `Revoked` immediately (no grace; Play has explicitly revoked the entitlement). Consumers wire `emitExternalRevocation` against their RTDN→FCM pipeline (or whatever transport carries refund/chargeback signals); see [Server-driven revocation](server-driven-revocation.md).
+- `OwnedPurchases.Live` and `OwnedPurchases.Recovered` are **grant-only**. For each `PURCHASED`-state purchase, `productKeySelector` is applied; a non-null result transitions that key to `Granted` and persists. A *non-match* (selector returns null) does **not** revoke. `Live` can carry `UNSPECIFIED_STATE` entries or products unrelated to any tracked entitlement, and `Recovered` only emits the unacknowledged subset (an already-acked entitlement won't appear in it). Treating either as authoritative for revocation would falsely revoke users with already-acknowledged purchases.
+- `FlowOutcome.Failure` triggers `InGrace` for every currently-Granted or InGrace key (or transitions them straight to `Revoked` if the policy window is zero or has already elapsed since that key's last confirmation).
+- `PurchaseRevoked` matched against *any* key's `lastConfirmedSnapshot.purchaseToken` transitions that key (and only that key) to `Revoked` immediately (no grace; Play has explicitly revoked the entitlement). Consumers wire `emitExternalRevocation` against their RTDN→FCM pipeline; see [Server-driven revocation](server-driven-revocation.md).
 
 The remaining `FlowOutcome` variants (`Pending`, `Canceled`, `ItemAlreadyOwned`, `ItemUnavailable`, `UnknownResponse`) are no-ops; they don't change owned-purchase state, and `Pending` must not grant entitlement (per Play's rules).
 
 ## Storage is your responsibility
 
-The library doesn't pick a persistence library. Implement `EntitlementStorage` against whatever your app already uses (DataStore, EncryptedSharedPreferences, Room, signed prefs against a server-issued key). The interface is two suspend functions:
+The library doesn't pick a persistence library. Implement `EntitlementStorage<K>` against whatever your app already uses (DataStore, EncryptedSharedPreferences, Room, signed prefs against a server-issued key). The interface is two suspend functions:
 
 ```kotlin
-interface EntitlementStorage {
-    suspend fun read(): EntitlementSnapshot?
-    suspend fun write(snapshot: EntitlementSnapshot)
+interface EntitlementStorage<K : Any> {
+    suspend fun readAll(): Map<K, EntitlementSnapshot>
+    suspend fun write(key: K, snapshot: EntitlementSnapshot)
 }
 ```
 
-`EntitlementSnapshot` is plain data: `(isEntitled: Boolean, confirmedAtMs: Long, purchaseToken: String?)`. The cache calls `read()` once on `start()` to hydrate, then `write()` on every entitlement-affecting transition. `InGrace` is **not** persisted — grace re-derives from the most recent confirmed `confirmedAtMs` on read, which keeps an attacker who can manipulate storage from extending the window indefinitely.
+Your implementation is responsible for serializing `K` to a stable on-disk identifier. For `String` keys that's the identity; for `enum class` keys use `K.name` (not `toString()` — it's overridable); for sealed classes pick a stable discriminator field. Stability across app upgrades matters — renaming an enum constant breaks the on-disk mapping.
+
+`EntitlementSnapshot` is plain data: `(isEntitled: Boolean, confirmedAtMs: Long, purchaseToken: String?)`. The cache calls `readAll()` once on `start()` to hydrate, then `write(key, snapshot)` on every entitlement-affecting transition. `InGrace` is **not** persisted — grace re-derives from the most recent confirmed `confirmedAtMs` on read, which keeps an attacker who can manipulate storage from extending the window indefinitely.
 
 For most apps the on-device storage is fine: a tampered snapshot gets overwritten the next time `OwnedPurchases.Live` or `OwnedPurchases.Recovered` confirms (or fails to confirm via `PurchaseRevoked`) the entitlement. The cache trusts what storage returns.
 
 ## Tamper-resistant storage
 
-If your threat model includes users tampering with on-device storage to extend entitlement (freemium apps where premium has real value), wrap your `EntitlementStorage` in `SignedEntitlementStorage`. The decorator signs the snapshot on every write and verifies the signature on read; tampered snapshots are dropped (the cache reads them as cold-start and the next `OwnedPurchases.Live` or `OwnedPurchases.Recovered` re-confirms truth).
+If your threat model includes users tampering with on-device storage to extend entitlement (freemium apps where the paid entitlement has real value), wrap your `EntitlementStorage<K>` in `SignedEntitlementStorage<K>`. The decorator signs each snapshot on every write (using a key-aware canonical encoding so cross-key sig swaps fail verification) and verifies the signature on read; tampered snapshots are dropped (the cache reads them as cold-start for that key, and the next `OwnedPurchases.Live` or `OwnedPurchases.Recovered` re-confirms truth).
 
 ```kotlin
 import com.kanetik.billing.entitlement.signed.*
 
-val storage: EntitlementStorage = SignedEntitlementStorage(
+val storage: EntitlementStorage<GameEntitlement> = SignedEntitlementStorage(
     delegate = MyDataStoreEntitlementStorage(context),
     keyProvider = KeystoreBackedKeyProvider.create(),
     signatureStore = SharedPreferencesSignatureStore(context),
-    onTamperDetected = { event ->
+    keyToStorageId = { it.name },   // stable string per K instance
+    onTamperDetected = { entitlementKey, event ->
         when (event) {
-            TamperEvent.MissingSignature -> logger.info("First read after upgrade")
-            TamperEvent.InvalidSignature -> logger.warn("Possible tampering detected")
-            is TamperEvent.UnsupportedVersion -> logger.warn("Unknown sig version ${event.version}")
+            TamperEvent.MissingSignature -> logger.info("First read for $entitlementKey")
+            TamperEvent.InvalidSignature -> logger.warn("Possible tampering on $entitlementKey")
+            is TamperEvent.UnsupportedVersion ->
+                logger.warn("Unknown sig version ${event.version} on $entitlementKey")
         }
     },
 )
-val cache = EntitlementCache(purchasesUpdates, storage, gracePolicy, productPredicate)
+val cache = EntitlementCache(purchasesUpdates, storage, gracePolicy, productKeySelector)
 ```
 
-`SignedEntitlementStorage` keeps the library neutral on the persistence backend — the underlying `EntitlementStorage` still owns the snapshot bytes, the signature blob lives separately in `SignatureStore`. Pick `KeystoreBackedKeyProvider` (the recommended default; uses Android Keystore HMAC keys, hardware-backed where available) or `ServerSeededKeyProvider` (per-install seed from your backend, cached locally — see its KDoc for the plaintext-cache caveat). The library can't enforce key non-extractability and isn't a replacement for server-side validation; both caveats are documented on the relevant types.
+`SignedEntitlementStorage` keeps the library neutral on the persistence backend — the underlying `EntitlementStorage` still owns the snapshot bytes, the signature blobs (one per entitlement key) live separately in `SignatureStore`. Pick `KeystoreBackedKeyProvider` (the recommended default; uses Android Keystore HMAC keys, hardware-backed where available) or `ServerSeededKeyProvider` (per-install seed from your backend, cached locally — see its KDoc for the plaintext-cache caveat). The library can't enforce key non-extractability and isn't a replacement for server-side validation; both caveats are documented on the relevant types.
 
-`onTamperDetected` distinguishes three cases via the `TamperEvent` sealed type. The most common one in practice is `MissingSignature` — fired the first time the decorator reads a snapshot that was written by a release without `SignedEntitlementStorage`. Treat it differently from `InvalidSignature` in your telemetry; the latter is the strong tamper indicator.
+`onTamperDetected` receives the entitlement key (as serialized via `keyToStorageId`) along with the typed `TamperEvent`. A tamper on one key doesn't affect the others — verified snapshots for the unaffected keys still flow through. The most common event in practice is `MissingSignature` — fired the first time the decorator reads a snapshot that was written by a release without `SignedEntitlementStorage`. Treat it differently from `InvalidSignature` in your telemetry; the latter is the strong tamper indicator.
 
 ### Migrating an existing unsigned snapshot
 
-By default, the first read after wrapping an existing unsigned snapshot fires `TamperEvent.MissingSignature` and returns null — a one-time cold-start. The next `OwnedPurchases.Live` or `OwnedPurchases.Recovered` confirmation re-establishes truth and writes a signature on the transition. That's the secure default: no perpetual "delete the signature file to bypass" attack window.
+By default, the first read after wrapping an existing unsigned snapshot fires `TamperEvent.MissingSignature` and omits that key from the verified map — a one-time cold-start for that entitlement. The next `OwnedPurchases.Live` or `OwnedPurchases.Recovered` confirmation re-establishes truth and writes a signature on the transition. That's the secure default: no perpetual "delete the signature file to bypass" attack window.
 
-If you'd rather avoid the cold-start (UX over strict-from-day-one tamper resistance), call `SignedEntitlementStorage.migrateUnsignedSnapshot` once on first launch after upgrade, guarded by your own marker. `migrateUnsignedSnapshot` is `suspend`, so call it from a coroutine — and call it **before** constructing the `SignedEntitlementStorage` that wraps the same trio, so the cache's first read sees the signature you just wrote:
+If you'd rather avoid the cold-start (UX over strict-from-day-one tamper resistance), call `SignedEntitlementStorage.migrateUnsignedSnapshot` once per entitlement on first launch after upgrade, guarded by your own marker:
 
 ```kotlin
-suspend fun bootstrapEntitlementStorage(context: Context): EntitlementStorage {
+suspend fun bootstrapEntitlementStorage(context: Context): EntitlementStorage<GameEntitlement> {
     val rawStorage = MyDataStoreEntitlementStorage(context)
     val keyProvider = KeystoreBackedKeyProvider.create()
     val sigStore = SharedPreferencesSignatureStore(context)
 
     if (!prefs.getBoolean("entitlement_signed_migrated", false)) {
-        SignedEntitlementStorage.migrateUnsignedSnapshot(rawStorage, keyProvider, sigStore)
+        for (entitlement in GameEntitlement.values()) {
+            SignedEntitlementStorage.migrateUnsignedSnapshot(
+                entitlementKey = entitlement.name,
+                entitlementCacheKey = entitlement,
+                delegate = rawStorage,
+                keyProvider = keyProvider,
+                signatureStore = sigStore,
+            )
+        }
         prefs.edit().putBoolean("entitlement_signed_migrated", true).apply()
     }
-    return SignedEntitlementStorage(rawStorage, keyProvider, sigStore, onTamperDetected = { ... })
+    return SignedEntitlementStorage(
+        delegate = rawStorage,
+        keyProvider = keyProvider,
+        signatureStore = sigStore,
+        keyToStorageId = { it.name },
+        onTamperDetected = { _, _ -> },
+    )
 }
 ```
 

--- a/docs/guides/error-handling.md
+++ b/docs/guides/error-handling.md
@@ -71,12 +71,12 @@ The library doesn't ship localized user-facing strings; tone, voice, and languag
 
 ## Handling `handlePurchase` failures correctly
 
-`handlePurchase` returns a sealed `HandlePurchaseResult`: `Success`, `AlreadyAcknowledged`, `NotPurchased`, `NotOwned`, or `Failure(exception)`. The compiler nudges you to branch on each. **Grant entitlement on `Success` and `AlreadyAcknowledged` (both safe), nothing else.** Play auto-refunds the unacknowledged purchase within ~3 days and the user's premium silently evaporates if you grant on a `Failure` and the underlying ack call doesn't recover.
+`handlePurchase` returns a sealed `HandlePurchaseResult`: `Success`, `AlreadyAcknowledged`, `NotPurchased`, `NotOwned`, or `Failure(exception)`. The compiler nudges you to branch on each. **Grant entitlement on `Success` and `AlreadyAcknowledged` (both safe), nothing else.** Play auto-refunds the unacknowledged purchase within ~3 days and the paid-for feature silently evaporates if you grant on a `Failure` and the underlying ack call doesn't recover.
 
 ```kotlin
 when (val r = billing.handlePurchase(purchase, consume = false)) {
-    HandlePurchaseResult.Success -> grantPremium()
-    HandlePurchaseResult.AlreadyAcknowledged -> grantPremium() // no PBL call made; safe
+    HandlePurchaseResult.Success -> grantEntitlement()
+    HandlePurchaseResult.AlreadyAcknowledged -> grantEntitlement() // no PBL call made; safe
     HandlePurchaseResult.NotPurchased -> {} // pending — wait for terminal state
     HandlePurchaseResult.NotOwned -> {
         // Play says this purchase isn't owned anymore (stale snapshot,

--- a/docs/guides/multi-offer-products.md
+++ b/docs/guides/multi-offer-products.md
@@ -1,6 +1,6 @@
 # Pre-order / multi-offer one-time products
 
-Play Billing lets a one-time product carry multiple offers (e.g., a pre-order discount alongside the regular price). The `toOneTimeFlowParams` extension takes an optional selector:
+Play Billing lets a one-time product carry multiple offers — a pre-order discount alongside the regular price, alternative price tiers, etc. The `toOneTimeFlowParams` extension takes an optional selector:
 
 ```kotlin
 val params = productDetails.toOneTimeFlowParams(
@@ -12,3 +12,25 @@ val params = productDetails.toOneTimeFlowParams(
 ```
 
 Default selector picks the first offer. If your app has only one offer per product, you can ignore the parameter.
+
+## Pre-orders: use `isPreorder`
+
+PBL 8.1+ exposes pre-order metadata via `OneTimePurchaseOfferDetails.preorderDetails`. The library wraps that as a `Boolean` extension for ergonomic switching:
+
+```kotlin
+import com.kanetik.billing.ext.isPreorder
+
+val params = productDetails.toOneTimeFlowParams(
+    offerSelector = { offers ->
+        val preorder = offers.firstOrNull { it.isPreorder }
+        val regular = offers.firstOrNull { !it.isPreorder }
+        if (userOptedIntoPreorder) preorder ?: regular else regular ?: preorder
+    }
+)
+```
+
+Three wrinkles to remember when wiring pre-orders:
+
+- The purchase shows up as `FlowOutcome.Pending` until Play fulfills it on the release date — **do not grant entitlement on that pending event**. Wait for the matching `OwnedPurchases.Live` update that arrives when fulfillment lands.
+- The user can cancel a pending pre-order from the Play Store before the release date. Play surfaces the cancellation server-side via the Voided Purchases API (no client event today). Apps that pre-grant feature access on pre-order signup should reconcile against the Voided Purchases API via their backend before treating the entitlement as durable.
+- One product can carry both pre-order and standard offers simultaneously. The `isPreorder` predicate is how you branch the selector.

--- a/docs/guides/multi-quantity.md
+++ b/docs/guides/multi-quantity.md
@@ -1,6 +1,14 @@
 # Granting entitlement: multi-quantity
 
-Play supports multi-quantity purchases for consumables (the *Multi-quantity purchases* flag must be enabled per-product in Play Console; the user picks the quantity in the Play purchase dialog). Always grant `purchase.quantity` units, not 1 — and only grant after `handlePurchase` returns `Success`:
+Play supports multi-quantity purchases for consumables. The mechanism is entirely Play-Console- and Play-dialog-driven on PBL 9 — there's no client-side `setPurchaseQuantity` knob — but your code still has to read the resulting quantity off the `Purchase` and grant accordingly.
+
+## What the client controls (nothing)
+
+You enable *Multi-quantity purchases* on the product in Play Console. From then on, Play's own purchase dialog renders a quantity picker; the user picks N units; Play processes the whole transaction and returns one `Purchase` whose `purchase.quantity` field carries the unit count. The library wrapper calls `toOneTimeFlowParams(...)` the same way for any quantity — there is no per-launch quantity to set from your code on PBL 9.
+
+## What the client must do (read `purchase.quantity` and grant accordingly)
+
+Always grant `purchase.quantity` units, not 1 — and only grant after `handlePurchase` returns `Success`:
 
 ```kotlin
 private suspend fun handle(purchase: Purchase) {
@@ -19,4 +27,6 @@ private suspend fun handle(purchase: Purchase) {
 }
 ```
 
-`purchase.quantity` defaults to `1` so single-unit code keeps working — but ignoring it on a multi-quantity purchase silently under-grants. The library handles the *acknowledgement* side correctly for any quantity (Play's consume API consumes the whole purchase regardless of unit count); only your entitlement-grant code needs the awareness.
+`purchase.quantity` defaults to `1` so single-unit code keeps working — but ignoring it on a multi-quantity purchase silently under-grants. The library handles the *acknowledgement* side correctly for any quantity (Play's consume API consumes the whole purchase regardless of unit count); only your wallet-ledger code needs the awareness.
+
+For the broader pattern of tracking consumable balances (where multi-quantity purchases land), see the [Consumables ledger guide](consumables.md).

--- a/docs/guides/purchase-recovery.md
+++ b/docs/guides/purchase-recovery.md
@@ -11,7 +11,7 @@ PBL gives you one callback, `PurchasesUpdatedListener`, that fires for two seman
 - The user actually owns a purchase — they just completed one through your active flow, or one was already on their account from a prior session that didn't finish processing.
 - A launch attempt produced an outcome that *isn't* a purchase — they canceled the dialog, the product wasn't available in their region, the network dropped.
 
-Both arrive on the same listener with a `BillingResult` and a `List<Purchase>`. A naive integration treats them the same and writes the callback's purchase list to whatever entitlement state the app keeps. But a `USER_CANCELED` outcome carries an empty (or stale) purchase list, and writing that into a cache silently corrupts state. People have shipped real apps that revoke premium when the user taps Back on the purchase dialog.
+Both arrive on the same listener with a `BillingResult` and a `List<Purchase>`. A naive integration treats them the same and writes the callback's purchase list to whatever entitlement state the app keeps. But a `USER_CANCELED` outcome carries an empty (or stale) purchase list, and writing that into a cache silently corrupts state. People have shipped real apps that revoke a paid entitlement when the user taps Back on the purchase dialog.
 
 The library splits the callback into two sealed roots so the type system can catch this at compile time:
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,7 +6,7 @@ The library is published to Maven Central as `com.kanetik.billing:billing`.
 
 ```kotlin
 dependencies {
-    implementation("com.kanetik.billing:billing:0.1.2")
+    implementation("com.kanetik.billing:billing:0.1.3")
 }
 ```
 
@@ -14,7 +14,7 @@ dependencies {
 
 ```groovy
 dependencies {
-    implementation 'com.kanetik.billing:billing:0.1.2'
+    implementation 'com.kanetik.billing:billing:0.1.3'
 }
 ```
 
@@ -22,7 +22,7 @@ dependencies {
 
 ```toml
 [versions]
-kanetik-billing = "0.1.2"
+kanetik-billing = "0.1.3"
 
 [libraries]
 kanetik-billing = { module = "com.kanetik.billing:billing", version.ref = "kanetik-billing" }
@@ -42,7 +42,7 @@ dependencies {
 <dependency>
     <groupId>com.kanetik.billing</groupId>
     <artifactId>billing</artifactId>
-    <version>0.1.2</version>
+    <version>0.1.3</version>
 </dependency>
 ```
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -58,7 +58,7 @@ class CheckoutActivity : ComponentActivity() {
             QueryProductDetailsParams.newBuilder()
                 .setProductList(listOf(
                     QueryProductDetailsParams.Product.newBuilder()
-                        .setProductId("premium_lifetime")
+                        .setProductId("pro_toolkit")
                         .setProductType(BillingClient.ProductType.INAPP)
                         .build()
                 ))
@@ -72,8 +72,8 @@ class CheckoutActivity : ComponentActivity() {
         // handlePurchase returns a sealed HandlePurchaseResult — branch on it.
         // See Error handling for the full pattern.
         when (val r = billing.handlePurchase(purchase, consume = false)) {
-            HandlePurchaseResult.Success -> grantPremium()
-            HandlePurchaseResult.AlreadyAcknowledged -> grantPremium() // safe — no PBL call needed
+            HandlePurchaseResult.Success -> grantEntitlement()
+            HandlePurchaseResult.AlreadyAcknowledged -> grantEntitlement() // safe — no PBL call needed
             HandlePurchaseResult.NotPurchased -> {} // pending — wait for terminal state
             HandlePurchaseResult.NotOwned -> {} // Play says not owned — defer to grace/revoke logic
             is HandlePurchaseResult.Failure -> showError(r.exception.userFacingCategory)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -172,14 +172,14 @@ Beyond the levels above, you'll want to test your own ViewModels, repositories, 
 Many apps short-circuit the real billing repo entirely in debug builds and read entitlement from a `BuildConfig` flag or a debug-menu setting:
 
 ```kotlin
-// debug/.../PremiumManager.kt
-class PremiumManager @Inject constructor(...) {
-    val isPremium: StateFlow<Boolean> = MutableStateFlow(BuildConfig.DEBUG_PREMIUM_OVERRIDE)
+// debug/.../EntitlementManager.kt
+class EntitlementManager @Inject constructor(...) {
+    val isEntitled: StateFlow<Boolean> = MutableStateFlow(BuildConfig.DEBUG_ENTITLEMENT_OVERRIDE)
     // ...
 }
 ```
 
-This lets you develop premium UI without touching billing at all. Combine with Level 1 or Level 2 for tests that actually exercise the billing flow.
+This lets you develop gated UI without touching billing at all. Combine with Level 1 or Level 2 for tests that actually exercise the billing flow.
 
 ### Mocking `BillingRepository` in your unit tests
 
@@ -216,5 +216,5 @@ See the [Roadmap](roadmap.md) for the full v0.2.0 plan.
 | Force a specific BillingResult code | Level 3 — Play Billing Lab Response simulator |
 | Test region-specific pricing | Level 3 — Lab Configuration settings |
 | Test sub grace period / account hold / price change | Level 3 — Lab Subscription settings |
-| Develop premium UI without touching billing | Debug-flavor entitlement override |
+| Develop gated UI without touching billing | Debug-flavor entitlement override |
 | Unit-test code that depends on `BillingRepository` | mockk against the interface (until v0.2.0's `:billing-testing` ships) |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ nav:
       - Logging: guides/logging.md
       - Dependency injection: guides/dependency-injection.md
       - Multi-quantity purchases: guides/multi-quantity.md
+      - Consumables ledger: guides/consumables.md
       - Multi-offer products: guides/multi-offer-products.md
       - Product-details caching: guides/product-details-caching.md
       - In-app messaging: guides/in-app-messaging.md

--- a/sample/README.md
+++ b/sample/README.md
@@ -34,4 +34,4 @@ For non-consumables, change `handlePurchase(purchase, consume = true)` to `consu
 
 ## Why a project reference, not the published artifact?
 
-`sample/build.gradle.kts` uses `implementation(project(":billing"))` rather than `implementation("com.kanetik.billing:billing:0.1.2")`. Library changes propagate to the sample on the next rebuild — no `publishToMavenLocal` step required during library development. Consumers in their own projects use the Maven coordinate; the sample is a development tool, not a consumer.
+`sample/build.gradle.kts` uses `implementation(project(":billing"))` rather than `implementation("com.kanetik.billing:billing:0.1.3")`. Library changes propagate to the sample on the next rebuild — no `publishToMavenLocal` step required during library development. Consumers in their own projects use the Maven coordinate; the sample is a development tool, not a consumer.

--- a/sample/src/main/kotlin/com/kanetik/billing/sample/SampleViewModel.kt
+++ b/sample/src/main/kotlin/com/kanetik/billing/sample/SampleViewModel.kt
@@ -44,7 +44,11 @@ class SampleViewModel(application: Application) : AndroidViewModel(application) 
 
     // Demo-only in-memory storage. Real apps implement EntitlementStorage
     // against DataStore / EncryptedSharedPreferences / signed prefs.
-    private val entitlementStorage: EntitlementStorage = InMemoryEntitlementStorage()
+    //
+    // Single-entitlement sample uses K = Unit. Multi-entitlement apps would
+    // pick a String / enum / sealed-class key here. See the EntitlementCache
+    // KDoc for the K = String + multi-product example.
+    private val entitlementStorage: EntitlementStorage<Unit> = InMemoryEntitlementStorage()
 
     private val entitlementCache = EntitlementCache(
         purchasesUpdates = billing.observePurchaseUpdates(),
@@ -56,7 +60,13 @@ class SampleViewModel(application: Application) : AndroidViewModel(application) 
             billingUnavailableMs = TimeUnit.HOURS.toMillis(72),
             transientFailureMs = TimeUnit.HOURS.toMillis(6),
         ),
-        productPredicate = { it.products.contains(TEST_PRODUCT_ID) },
+        productKeySelector = { purchase ->
+            // For multi-entitlement apps, branch on `purchase.products` and
+            // return the corresponding K. Return null for purchases that
+            // don't grant any tracked entitlement (e.g. consumable currency
+            // packs — those go through a wallet ledger, not this cache).
+            if (purchase.products.contains(TEST_PRODUCT_ID)) Unit else null
+        },
         logger = BillingLogger.Android,
     ).also {
         // start() suspends until hydration completes — launch it from the
@@ -71,7 +81,7 @@ class SampleViewModel(application: Application) : AndroidViewModel(application) 
 
     init {
         viewModelScope.launch {
-            entitlementCache.state.collect { entitlement ->
+            entitlementCache.stateFor(Unit).collect { entitlement ->
                 _state.update { it.copy(entitlement = entitlement) }
                 appendLog("entitlement -> ${entitlement::class.simpleName}")
             }
@@ -101,11 +111,12 @@ class SampleViewModel(application: Application) : AndroidViewModel(application) 
                         // Recovered is no longer required.
                     }
                     is PurchaseRevoked -> {
-                        // Real apps revoke entitlement here (clear premium flag, kick
-                        // back to a paywall, etc.). The sample just logs — the goal of
-                        // showing this branch is to demonstrate that revocation events
-                        // arrive on the same flow as OwnedPurchases / FlowOutcome, so
-                        // consumers don't need to maintain a parallel pipeline.
+                        // Real apps revoke entitlement here (clear the unlock flag,
+                        // kick back to a paywall, etc.). The sample just logs — the
+                        // goal of showing this branch is to demonstrate that
+                        // revocation events arrive on the same flow as
+                        // OwnedPurchases / FlowOutcome, so consumers don't need to
+                        // maintain a parallel pipeline.
                         appendLog("revoked: ${event.purchaseToken} (${event.reason})")
                     }
                 }
@@ -238,13 +249,18 @@ data class SampleUiState(
  * Demo-only [EntitlementStorage] backed by an in-process variable. Survives
  * the activity lifecycle (the ViewModel survives configuration changes) but
  * not process death. Real apps implement against DataStore / signed prefs.
+ *
+ * Single-key (K = Unit) for the sample's one test SKU. A multi-entitlement
+ * app would back this with a `Map<K, EntitlementSnapshot>` in DataStore or
+ * Room and key reads/writes by `K`.
  */
-private class InMemoryEntitlementStorage : EntitlementStorage {
+private class InMemoryEntitlementStorage : EntitlementStorage<Unit> {
     @Volatile private var snapshot: EntitlementSnapshot? = null
 
-    override suspend fun read(): EntitlementSnapshot? = snapshot
+    override suspend fun readAll(): Map<Unit, EntitlementSnapshot> =
+        snapshot?.let { mapOf(Unit to it) } ?: emptyMap()
 
-    override suspend fun write(snapshot: EntitlementSnapshot) {
+    override suspend fun write(key: Unit, snapshot: EntitlementSnapshot) {
         this.snapshot = snapshot
     }
 }


### PR DESCRIPTION
## Summary

- **Drops single-binary-entitlement assumption.** `EntitlementCache` becomes `EntitlementCache<K : Any>` — multi-SKU apps (multiple non-consumable upgrades, game shops with both unlocks and consumable currency) can now track per-key entitlement state without rolling their own state machine. `productPredicate` → `productKeySelector: (Purchase) -> K?`; `state` is now `StateFlow<Map<K, EntitlementState>>` with `stateFor(key: K)` convenience.
- **Per-key signed storage** with cross-key sig-swap detection — `SignedEntitlementStorage<K>` takes a `keyToStorageId: (K) -> String` and v2 canonical bytes include the key. v1 sigs still verify (single-entitlement upgraders see no spurious `InvalidSignature`).
- **Adds `OneTimePurchaseOfferDetails.isPreorder`** extension (sugar over `preorderDetails != null`). Multi-quantity helper dropped from scope after discovering PBL 9 doesn't expose `setPurchaseQuantity` on the client builder; multi-quantity guide updated accordingly.
- **New [Consumables ledger guide](https://kanetik.github.io/billing-library/guides/consumables/)** documents the wallet-on-the-side pattern for SKUs that are credits, not entitlements.
- **Docs / KDoc sweep**: "premium" framing → use-case-agnostic naming across 10 source files + 5 docs pages. Library API was already mostly neutral at the protocol layer; this aligns first-impression docs with that.

## Migration (0.1.2 → 0.1.3)

Single-entitlement consumers: pick `K = Unit` (or a `data object` key), return that key from `productKeySelector` for the matching product (`null` otherwise), and port your `EntitlementStorage` to a one-entry-map shape. The single-line `stateFor(yourKey)` returns the same per-key `Flow<EntitlementState>` you'd previously bound to UI.

Full breaking-change inventory + migration notes in [CHANGELOG.md](CHANGELOG.md).

## Test plan

- [x] `./gradlew :billing:testDebugUnitTest` — green (incl. new multi-key, per-key revocation, per-key grace, cross-key sig-swap, v1+v2 canonical-bytes tests)
- [x] `./gradlew :billing:compileDebugKotlin :sample:compileDebugKotlin` — green
- [ ] Manual sample-app smoke test (single-entitlement flow with `K = Unit`)
- [ ] Wakey migration (0.1.2 → 0.1.3) — confirm `K = Unit` shape and storage migration are ergonomic in a real app

🤖 Generated with [Claude Code](https://claude.com/claude-code)