### PR TITLE
ci: auto-create GitHub Release on tag push + [Unreleased] placeholder support

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -62,14 +62,39 @@ jobs:
 
       - name: Derive version + tag
         id: meta
+        # User-controlled inputs (workflow_dispatch input, tag ref name) are
+        # passed via `env:` rather than `${{ ... }}` template interpolation
+        # inside the shell script. Template interpolation rewrites the script
+        # text before bash sees it, so a malicious tag like
+        # `v0.1.3$(rm -rf /)` would trigger command substitution at assignment
+        # time, BEFORE any validation could run. Env vars are bound at
+        # process start and accessed via normal parameter expansion ("$VAR"),
+        # which treats the value literally.
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_REF: ${{ github.ref_name }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            INPUT="${{ inputs.version }}"
+            INPUT="$INPUT_VERSION"
           else
-            INPUT="${GITHUB_REF_NAME}"
+            INPUT="$INPUT_REF"
           fi
           # Accept both `v0.1.3` and `0.1.3` forms; canonicalize.
           VERSION="${INPUT#v}"
+          # SemVer-shaped validation: X.Y.Z with an optional pre-release
+          # suffix of dot-separated alphanumeric identifiers (e.g., `beta1`,
+          # `rc.2`). Rejects whitespace, control chars, and shell
+          # metacharacters by construction — the character class is narrow.
+          # Defense in depth: the env-var path above already prevents
+          # injection at assignment time; this regex enforces "the value is
+          # a release version we know how to handle" so downstream steps
+          # (gh release create, git checkout, CHANGELOG match) don't get
+          # surprising tag shapes.
+          if ! printf '%s' "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'; then
+            echo "::error::Version '$VERSION' is not a valid X.Y.Z or X.Y.Z-<prerelease> form."
+            echo "Accepted: '0.1.3', '0.1.3-beta1', '0.1.3-rc.2'. Rejected: anything with whitespace, slashes, or shell metacharacters."
+            exit 1
+          fi
           TAG="v${VERSION}"
           # Pre-release detection: anything containing `-` (e.g., `0.1.3-beta1`).
           if printf '%s' "$VERSION" | grep -q -- '-'; then
@@ -88,20 +113,23 @@ jobs:
         # default branch HEAD — main may have moved on since the tag.
         # Tag pushes already check out the tag; only the dispatch path
         # needs the explicit switch.
+        env:
+          TAG: ${{ steps.meta.outputs.tag }}
         run: |
-          if ! git rev-parse --verify "refs/tags/${{ steps.meta.outputs.tag }}" >/dev/null 2>&1; then
-            echo "::error::Tag ${{ steps.meta.outputs.tag }} does not exist. Create + push the tag before running this workflow."
+          if ! git rev-parse --verify "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "::error::Tag $TAG does not exist. Create + push the tag before running this workflow."
             exit 1
           fi
-          git checkout "${{ steps.meta.outputs.tag }}"
+          git checkout "$TAG"
 
       - name: Skip if release already exists
         id: existing
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.meta.outputs.tag }}
         run: |
-          if gh release view "${{ steps.meta.outputs.tag }}" >/dev/null 2>&1; then
-            echo "::notice::Release ${{ steps.meta.outputs.tag }} already exists — skipping. (To regenerate, delete the release and re-run via workflow_dispatch.)"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "::notice::Release $TAG already exists — skipping. (To regenerate, delete the release and re-run via workflow_dispatch.)"
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
@@ -110,8 +138,9 @@ jobs:
       - name: Extract CHANGELOG section
         if: steps.existing.outputs.exists == 'false'
         id: extract
+        env:
+          VER: ${{ steps.meta.outputs.version }}
         run: |
-          VER="${{ steps.meta.outputs.version }}"
           BODY_FILE="$(mktemp)"
           # index()-based matching (not regex) so `[`, `]`, and `.` in the
           # version need no escaping. Print everything from the
@@ -142,14 +171,18 @@ jobs:
         if: steps.existing.outputs.exists == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.meta.outputs.tag }}
+          PRERELEASE: ${{ steps.meta.outputs.prerelease }}
+          BODY_FILE: ${{ steps.extract.outputs.body_file }}
+          REPO: ${{ github.repository }}
         run: |
           PRE_FLAG=""
-          if [ "${{ steps.meta.outputs.prerelease }}" = "true" ]; then
+          if [ "$PRERELEASE" = "true" ]; then
             PRE_FLAG="--prerelease"
           fi
-          gh release create "${{ steps.meta.outputs.tag }}" \
-            --title "${{ steps.meta.outputs.tag }}" \
-            --notes-file "${{ steps.extract.outputs.body_file }}" \
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --notes-file "$BODY_FILE" \
             --verify-tag \
             $PRE_FLAG
-          echo "::notice::Created release at https://github.com/${{ github.repository }}/releases/tag/${{ steps.meta.outputs.tag }}"
+          echo "::notice::Created release at https://github.com/$REPO/releases/tag/$TAG"

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -1,0 +1,158 @@
+name: GitHub Release
+
+# Creates a GitHub Release whose body is the matching `## [X.Y.Z] - <date>`
+# section from CHANGELOG.md at the tagged commit.
+#
+# Runs in parallel with `publish.yml` (Maven Central staging upload) and
+# `post-release-doc-bump.yml` (install pin + CHANGELOG sync). There is no
+# ordering requirement — this workflow only depends on the tag existing
+# and CHANGELOG.md being committed at the tagged commit.
+#
+# Maven Central caveat: a successful run here only means a GitHub Release
+# page exists. The Maven coordinate may not resolve for ~30 min after the
+# human clicks "Release" in the Sonatype Central Portal — consumers who
+# pin to the new version immediately after seeing the GH Release will hit
+# a resolution error until Central propagates. Acceptable in practice;
+# the alternative (gating GH Release on Central propagation) would need
+# a polling step against repo1.maven.org that doesn't add much value.
+#
+# Idempotent: if a release for the tag already exists, the workflow is
+# a no-op — it does NOT overwrite the body. To regenerate, delete the
+# release manually and re-run via workflow_dispatch.
+#
+# Stable vs pre-release: tags containing `-` (e.g., `v0.1.3-beta1`) are
+# marked `--prerelease`. Matches the `post-release-doc-bump.yml` skip
+# rule for what counts as a stable tag.
+#
+# `workflow_dispatch` accepts a `version` input for backfill — useful
+# when this workflow was added after a tag was pushed, or when a prior
+# run failed and was deleted.
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to create a GitHub Release for (e.g., 0.1.3 or v0.1.3). Must have a matching '## [X.Y.Z] - <date>' section in CHANGELOG.md at the tagged commit."
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+# Queue rather than cancel — release creation is short and shouldn't be
+# interrupted by a rapid second tag push.
+concurrency:
+  group: github-release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  create-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Need full history so the dispatch path can check out the tagged
+          # commit. Tag pushes already check out the tag, so this is mainly
+          # for workflow_dispatch backfill.
+          fetch-depth: 0
+
+      - name: Derive version + tag
+        id: meta
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            INPUT="${{ inputs.version }}"
+          else
+            INPUT="${GITHUB_REF_NAME}"
+          fi
+          # Accept both `v0.1.3` and `0.1.3` forms; canonicalize.
+          VERSION="${INPUT#v}"
+          TAG="v${VERSION}"
+          # Pre-release detection: anything containing `-` (e.g., `0.1.3-beta1`).
+          if printf '%s' "$VERSION" | grep -q -- '-'; then
+            PRERELEASE=true
+          else
+            PRERELEASE=false
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "prerelease=$PRERELEASE" >> "$GITHUB_OUTPUT"
+          echo "Creating GitHub Release for tag: $TAG (prerelease=$PRERELEASE)"
+
+      - name: Check out tagged commit (dispatch only)
+        if: github.event_name == 'workflow_dispatch'
+        # CHANGELOG.md must be read at the tagged commit, not at the
+        # default branch HEAD — main may have moved on since the tag.
+        # Tag pushes already check out the tag; only the dispatch path
+        # needs the explicit switch.
+        run: |
+          if ! git rev-parse --verify "refs/tags/${{ steps.meta.outputs.tag }}" >/dev/null 2>&1; then
+            echo "::error::Tag ${{ steps.meta.outputs.tag }} does not exist. Create + push the tag before running this workflow."
+            exit 1
+          fi
+          git checkout "${{ steps.meta.outputs.tag }}"
+
+      - name: Skip if release already exists
+        id: existing
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "${{ steps.meta.outputs.tag }}" >/dev/null 2>&1; then
+            echo "::notice::Release ${{ steps.meta.outputs.tag }} already exists — skipping. (To regenerate, delete the release and re-run via workflow_dispatch.)"
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Extract CHANGELOG section
+        if: steps.existing.outputs.exists == 'false'
+        id: extract
+        run: |
+          VER="${{ steps.meta.outputs.version }}"
+          BODY_FILE="$(mktemp)"
+          # index()-based matching (not regex) so `[`, `]`, and `.` in the
+          # version need no escaping. Print everything from the
+          # `## [VER] - ` line (exclusive) up to (but excluding) the next
+          # `## [...` heading. Trim leading + trailing blank lines so the
+          # release body starts at the first content line and ends cleanly.
+          awk -v ver="$VER" '
+            BEGIN { needle = "## [" ver "] - "; found = 0 }
+            index($0, needle) == 1 { found = 1; next }
+            found && index($0, "## [") == 1 { exit }
+            found { lines[++n] = $0 }
+            END {
+              first = 1
+              while (first <= n && lines[first] == "") first++
+              while (n >= first && lines[n] == "") n--
+              for (i = first; i <= n; i++) print lines[i]
+            }
+          ' CHANGELOG.md > "$BODY_FILE"
+          if [ ! -s "$BODY_FILE" ]; then
+            echo "::error::No '## [${VER}] - <date>' section found in CHANGELOG.md at this commit, or section is empty."
+            echo "Confirm the heading uses the exact form '## [${VER}] - YYYY-MM-DD'."
+            exit 1
+          fi
+          echo "body_file=$BODY_FILE" >> "$GITHUB_OUTPUT"
+          echo "Extracted $(wc -l < "$BODY_FILE") lines of release notes."
+
+      - name: Create GitHub Release
+        if: steps.existing.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PRE_FLAG=""
+          if [ "${{ steps.meta.outputs.prerelease }}" = "true" ]; then
+            PRE_FLAG="--prerelease"
+          fi
+          gh release create "${{ steps.meta.outputs.tag }}" \
+            --title "${{ steps.meta.outputs.tag }}" \
+            --notes-file "${{ steps.extract.outputs.body_file }}" \
+            --verify-tag \
+            $PRE_FLAG
+          echo "::notice::Created release at https://github.com/${{ github.repository }}/releases/tag/${{ steps.meta.outputs.tag }}"

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -1,7 +1,10 @@
 name: GitHub Release
 
-# Creates a GitHub Release whose body is the matching `## [X.Y.Z] - <date>`
-# section from CHANGELOG.md at the tagged commit.
+# Creates a GitHub Release whose body is the *contents* of the matching
+# `## [X.Y.Z] - <date>` section in CHANGELOG.md at the tagged commit —
+# the heading itself is excluded (the GH Release page already shows the
+# tag as the title; duplicating `## [X.Y.Z] - <date>` in the body would
+# be redundant).
 #
 # Runs in parallel with `publish.yml` (Maven Central staging upload) and
 # `post-release-doc-bump.yml` (install pin + CHANGELOG sync). There is no
@@ -41,12 +44,6 @@ on:
 
 permissions:
   contents: write
-
-# Queue rather than cancel — release creation is short and shouldn't be
-# interrupted by a rapid second tag push.
-concurrency:
-  group: github-release-${{ github.ref }}
-  cancel-in-progress: false
 
 jobs:
   create-release:
@@ -134,8 +131,8 @@ jobs:
             }
           ' CHANGELOG.md > "$BODY_FILE"
           if [ ! -s "$BODY_FILE" ]; then
-            echo "::error::No '## [${VER}] - <date>' section found in CHANGELOG.md at this commit, or section is empty."
-            echo "Confirm the heading uses the exact form '## [${VER}] - YYYY-MM-DD'."
+            echo "::error::No '## [${VER}] - ' heading found in CHANGELOG.md at this commit, or section is empty."
+            echo "Confirm a section heading starting with the exact prefix '## [${VER}] - ' exists (Keep-a-Changelog convention is '## [${VER}] - YYYY-MM-DD')."
             exit 1
           fi
           echo "body_file=$BODY_FILE" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/post-release-doc-bump.yml
+++ b/.github/workflows/post-release-doc-bump.yml
@@ -148,13 +148,35 @@ jobs:
           if grep -qE "^## \\[${VER_ESC}\\] - " CHANGELOG.md; then
             echo "CHANGELOG already has a section for ${VER}; skipping stamp."
           else
-            awk -v ver="$VER" -v date="$DATE" '
+            # When [Unreleased] is empty between releases, the CHANGELOG
+            # carries a placeholder line so the section doesn't look like
+            # an orphaned heading. On stamp:
+            #   1. Emit [Unreleased] + placeholder so the new release leaves
+            #      the next [Unreleased] in the same "empty + labeled" shape.
+            #   2. Insert the dated heading below.
+            #   3. Drop the OLD placeholder + its surrounding blanks from the
+            #      input so it doesn't fall through and reappear under the
+            #      new dated section. Any real entries that were under
+            #      [Unreleased] still fall through and land under the new
+            #      dated heading as before.
+            awk -v ver="$VER" -v date="$DATE" -v placeholder="No unreleased items at this time." '
               /^## \[Unreleased\]$/ && !done {
                 print
                 print ""
+                print placeholder
+                print ""
                 print "## [" ver "] - " date
+                print ""
                 done = 1
+                consume = 1
                 next
+              }
+              consume {
+                # Drop leading blanks and any existing placeholder until we
+                # hit real content. First non-blank, non-placeholder line
+                # exits consume mode and falls through to the default print.
+                if ($0 == "" || $0 == placeholder) next
+                consume = 0
               }
               { print }
             ' CHANGELOG.md > CHANGELOG.md.new && mv CHANGELOG.md.new CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+No unreleased items at this time.
+
 ## [0.1.3] - 2026-05-25
 
 ### Breaking


### PR DESCRIPTION
## Summary

Two related CI changes for the release flow:

1. **New `github-release.yml` workflow** — closes the gap that left every published tag without a Releases-page entry. Triggers on `v*` tag push (same trigger as `publish.yml` and `post-release-doc-bump.yml`), extracts the matching `## [X.Y.Z] - <date>` section contents from CHANGELOG.md at the tagged commit, and creates a GitHub Release with that as the body.

2. **`[Unreleased]` placeholder + `post-release-doc-bump.yml` awk fix** — CHANGELOG's empty `[Unreleased]` between releases now carries `No unreleased items at this time.` so the heading isn't visually orphaned. The doc-bump's awk script gets a small "consume" extension that drops the old placeholder + its surrounding blanks from the input on stamp, so the placeholder appears under the new `[Unreleased]` (not under the new dated section).

## Design notes — github-release.yml

- **Decoupled from `publish.yml`** — runs in parallel rather than as a downstream step. A publish-step failure shouldn't block release-page creation, and vice versa. The Maven Central propagation gap (~30 min from Portal Release click to consumer resolvability) is acceptable in practice.
- **Idempotent** — `gh release view` skip-if-exists check at the top. To regenerate, delete the release manually and re-run via `workflow_dispatch`.
- **Stable vs pre-release** — tags containing `-` (e.g., `v0.1.3-beta1`) get `--prerelease`. Mirrors the `post-release-doc-bump.yml` skip rule.
- **`workflow_dispatch` backfill** — accepts a `version` input (with or without leading `v`).
- **CHANGELOG extraction** uses awk `index()` (not regex) so `[`, `]`, and `.` in the version need no escaping. Trims leading + trailing blank lines.

## Design notes — placeholder

- The placeholder is intentional, stable text — a hint to humans that the empty section is empty *by design*, not by oversight.
- The awk update is small (~10 lines of state) and locally tested against three CHANGELOG shapes: placeholder-only `[Unreleased]`, real entries with no placeholder, and the migration case (empty `[Unreleased]` no placeholder — first run adds it).
- `github-release.yml`'s extraction is unaffected (bounds on `## [X.Y.Z] - <date>` headings; never looks inside `[Unreleased]`).
- `docs-freshness.yml` is unaffected (only checks `## [X.Y.Z] - <date>` heading presence).

## v0.1.3 catch-up

v0.1.3's release page was created manually using the github-release.yml extraction logic before committing the workflow — proving the script works against real CHANGELOG content. See https://github.com/kanetik/billing-library/releases/tag/v0.1.3.

## Test plan

- [ ] Workflow YAML parses (GitHub will validate on push).
- [ ] On the next tag push, observe `github-release.yml` runs successfully and creates a release with the matching CHANGELOG section as the body.
- [ ] On re-running the workflow against an existing tag, observe the skip-if-exists notice and no body overwrite.
- [ ] On the next tag push, observe `post-release-doc-bump.yml` correctly preserves the placeholder under `[Unreleased]` (not under the new dated section).
- [ ] `workflow_dispatch` with `version=0.1.3` against this branch (after merge) no-ops (release exists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
