### PR TITLE
build(deps): bump play-billing-ktx 9.0.0 → 9.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,9 +36,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bumped Play Billing Library `9.0.0` → `9.1.0` ([release notes](https://developer.android.com/google/play/billing/release-notes#9.1.0)).
-  Adds Billing Choice APIs (`getBillingChoiceInfoAsync`, `showBillingProgramInformationDialog`,
+  PBL 9.1.0 adds Billing Choice APIs (`getBillingChoiceInfoAsync`, `showBillingProgramInformationDialog`,
   `BillingChoiceInfo`, et al.) — net-new PBL surface the wrapper does not yet expose; see
-  feature-proposal issue for design discussion.
+  [#39](https://github.com/kanetik/billing-library/issues/39) for design discussion.
 
 ## [0.1.3] - 2026-05-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ConnectionRetryPolicy.None` to opt out and surface the first transient
   failure immediately (the pre-change behavior).
 
+## [0.1.4] - 2026-06-18
+
+### Changed
+
+- Bumped Play Billing Library `9.0.0` → `9.1.0` ([release notes](https://developer.android.com/google/play/billing/release-notes#9.1.0)).
+  Adds Billing Choice APIs (`getBillingChoiceInfoAsync`, `showBillingProgramInformationDialog`,
+  `BillingChoiceInfo`, et al.) — net-new PBL surface the wrapper does not yet expose; see
+  feature-proposal issue for design discussion.
+
 ## [0.1.3] - 2026-05-25
 
 ### Breaking

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@
 # pin in sync if AGP is bumped.
 androidGradlePlugin = "9.2.1"
 kotlin = "2.3.21"
-playBillingKtx = "9.0.0"
+playBillingKtx = "9.1.0"
 kotlinxCoroutines = "1.11.0"
 lifecycle = "2.10.0"
 coreKtx = "1.18.0"


### PR DESCRIPTION
Automated bump by daily PBL update Routine.

## Version delta

| | |
|---|---|
| Pinned | `9.0.0` |
| Latest stable | `9.1.0` |
| Release notes | https://developer.android.com/google/play/billing/release-notes#9.1.0 |
| Migration guide | N/A — no major boundary crossed (9.0.x → 9.1.0) |

## Categorization

**Safe — patch bump on `main`.**

9.1.0 adds only net-new Billing Choice APIs. No deprecations, removals, behavior changes, minSdk changes, or new manifest permissions touch any surface the wrapper already wraps. Classification per playbook rubric:

- `BillingClient.getBillingChoiceInfoAsync()` / `getBillingChoiceInfo()` — **net-new feature** (wrapper does not wrap it); routed to feature-proposal issue #39
- `BillingClient.showBillingProgramInformationDialog()` — **net-new feature**; routed to issue #39
- `BillingChoiceInfo`, `GetBillingChoiceInfoParams`, `BillingChoiceInfoResponseListener`, `BillingProgramInformationDialogParams`, `BillingProgramInformationDialogListener`, `BillingProgramAvailabilityDetails.BillingChoiceAvailabilityDetails`, `ChoiceScreenType` — supporting types for the net-new feature; routed to issue #39

No risky items in the 9.0.0 → 9.1.0 delta. Path A (safe / `main`).

(Path A never introduces net-new public surface in the wrapper. The Billing Choice overloads are non-trivial new feature area — not mechanical overloads of existing wrapped methods — so the zero-ambiguity exception does not apply. All design decisions deferred to issue #39.)

## Feature proposals deferred to follow-up issues

- #39: Billing Choice APIs (`getBillingChoiceInfo`, `showBillingProgramInformationDialog`, and supporting types) — see issue for design discussion.

## Verification

Verified locally in the remote execution environment (Android SDK installed on-demand):

- `:billing:test` — **166 tests passed, 0 failures**
- `:sample:assembleDebug` — **succeeded**
- `:billing:lint` — **clean**

## CHANGELOG

Stamped as `[0.1.4] - 2026-06-18`. Adjust the date at merge time if it slips.

## What the maintainer should do

1. Skim the [9.1.0 release notes](https://developer.android.com/google/play/billing/release-notes#9.1.0) and confirm the categorization (safe, Path A).
2. Triage issue #39 (Billing Choice APIs) — separate from this PR.
3. Merge this PR if happy.
4. Tag `v0.1.4` and push to trigger the publish workflow.

---
_Generated by [Claude Code](https://claude.ai/code/session_017yWJhLsuttyFck8DJstFVb)_