### PR TITLE
feat: add deterministic queryBillingAvailability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet._
+### Added
+
+- **Deterministic billing-availability check.** New
+  `BillingConnector.queryBillingAvailability(): BillingAvailability`
+  (`AVAILABLE` / `UNAVAILABLE` / `UNKNOWN`) disambiguates a *terminal* "this
+  device can't do Play Billing" state from a merely *transient* failure. The
+  raw `BILLING_UNAVAILABLE` (code 3) response is returned both when the Play
+  Store is genuinely absent **and** when billing is momentarily unavailable
+  (Play Store mid-update, account still syncing right after install), so it is
+  unsafe to gate irreversible decisions (free fallback grant, hiding a purchase
+  CTA) on it. The new check resolves the Play Store package presence/enabled
+  state offline first — only that produces the terminal `UNAVAILABLE`; a
+  present-Play-Store connection failure (including a transient code 3) or a
+  timeout maps to `UNKNOWN`, which callers must not treat as terminal.
+  Added as a **defaulted** interface method (returns `UNKNOWN`) so existing
+  hand-rolled `BillingConnector` / `BillingRepository` fakes keep compiling.
 
 ## [0.1.4] - 2026-06-21
 

--- a/billing/build.gradle.kts
+++ b/billing/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 // .github/workflows/publish.yml). Local builds get the SNAPSHOT default so
 // nothing accidentally publishes as a release version off main.
 group = "com.kanetik.billing"
-version = (findProperty("VERSION_NAME") as String?) ?: "0.1.4-SNAPSHOT"
+version = (findProperty("VERSION_NAME") as String?) ?: "0.1.5-SNAPSHOT"
 
 kotlin {
     // JVM 11 keeps the AAR consumable by any Android consumer on JDK 11+.

--- a/billing/src/main/AndroidManifest.xml
+++ b/billing/src/main/AndroidManifest.xml
@@ -1,4 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <!--
+        Package visibility (Android 11+ / API 30+). Without this <queries> entry the
+        PackageManager filters com.android.vending out of getApplicationInfo for
+        targetSdk 30+ consumers, throwing NameNotFoundException even when the Play
+        Store IS installed (e.g. sideloaded/internal builds where it isn't auto-visible).
+        That would make queryBillingAvailability() report a false-terminal UNAVAILABLE —
+        exactly the irreversible misclassification the API exists to prevent. Declaring
+        the package keeps the presence/enabled check honest.
+    -->
+    <queries>
+        <package android:name="com.android.vending" />
+    </queries>
 
 </manifest>

--- a/billing/src/main/kotlin/com/kanetik/billing/BillingAvailability.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/BillingAvailability.kt
@@ -1,0 +1,53 @@
+package com.kanetik.billing
+
+/**
+ * Whether Google Play Billing can be used on this device + install, as a
+ * **deterministic, terminal-vs-transient–aware** verdict.
+ *
+ * This exists because the raw Play response code `BILLING_UNAVAILABLE` (3) is
+ * ambiguous: it is returned both when the device genuinely cannot ever do Play
+ * Billing (no Play Store, restricted profile) **and** when billing is merely
+ * momentarily unavailable (Play Store mid-update, Google account still syncing
+ * right after install, Play Services updating). Treating a transient code 3 as
+ * a permanent "this device can't pay" verdict is a well-known footgun — a
+ * consumer that, say, grants a free ad-free tier to "can't pay" devices will
+ * mis-grant a normal user on a single unlucky first-launch hiccup and then
+ * never show them the upsell.
+ *
+ * [queryBillingAvailability][BillingConnector.queryBillingAvailability]
+ * disambiguates by checking the Play Store package itself (presence + enabled
+ * state — an offline, synchronous fact) before falling back to a connection
+ * attempt:
+ *  - Play Store absent/disabled → [UNAVAILABLE] (deterministic, safe to treat
+ *    as terminal).
+ *  - Play Store present + connection succeeds → [AVAILABLE].
+ *  - Play Store present + connection fails (including a transient code 3) →
+ *    [UNKNOWN] — **do not** treat as terminal; retry later.
+ */
+public enum class BillingAvailability {
+    /**
+     * Play Billing is usable: the Play Store package is present and enabled and
+     * a connection has succeeded. Safe to show purchase UI.
+     */
+    AVAILABLE,
+
+    /**
+     * Play Billing is **deterministically** unusable on this device: the Play
+     * Store package (`com.android.vending`) is not installed or is disabled.
+     * This is a stable, offline fact — safe to treat as terminal (e.g. to gate
+     * a no-Play fallback). It will not flip to [AVAILABLE] without the user
+     * installing/enabling the Play Store, at which point a fresh query reflects
+     * it.
+     */
+    UNAVAILABLE,
+
+    /**
+     * Indeterminate: the Play Store package is present, but a connection has not
+     * (yet) succeeded — a transient failure, a slow/cold connection, or a
+     * momentary `BILLING_UNAVAILABLE`. **Callers must not treat this as
+     * terminal.** Keep the user in a neutral/loading state and re-query later;
+     * do not make an irreversible decision (free grant, hiding the upsell) on
+     * [UNKNOWN].
+     */
+    UNKNOWN,
+}

--- a/billing/src/main/kotlin/com/kanetik/billing/BillingConnector.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/BillingConnector.kt
@@ -20,4 +20,31 @@ import kotlinx.coroutines.flow.SharedFlow
 public interface BillingConnector {
 
     public fun connectToBilling(): SharedFlow<BillingConnectionResult>
+
+    /**
+     * Deterministic verdict on whether Play Billing can be used on this device,
+     * disambiguating a *terminal* "this device can't pay" state from a merely
+     * *transient* failure — see [BillingAvailability] for why the raw
+     * `BILLING_UNAVAILABLE` response code can't be trusted for that distinction.
+     *
+     * Resolution order:
+     *  1. If the Play Store package is absent or disabled (an offline, stable
+     *     fact) → [BillingAvailability.UNAVAILABLE].
+     *  2. Otherwise attempt a connection (bounded by an internal timeout):
+     *     success → [BillingAvailability.AVAILABLE]; any failure, including a
+     *     transient code 3 → [BillingAvailability.UNKNOWN].
+     *
+     * Use this to gate irreversible decisions (granting a free fallback tier,
+     * permanently hiding a purchase CTA): act on [BillingAvailability.UNAVAILABLE]
+     * only, and keep [BillingAvailability.UNKNOWN] users in a neutral/retry state.
+     *
+     * Suspends until the determination is made. Safe to call from any thread.
+     *
+     * **Implementers, note:** this is a defaulted interface method returning
+     * [BillingAvailability.UNKNOWN] so existing hand-rolled fakes keep compiling;
+     * the real [BillingRepository] from [BillingRepositoryCreator.create]
+     * overrides it with the full resolution above.
+     */
+    public suspend fun queryBillingAvailability(): BillingAvailability =
+        BillingAvailability.UNKNOWN
 }

--- a/billing/src/main/kotlin/com/kanetik/billing/BillingRepositoryCreator.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/BillingRepositoryCreator.kt
@@ -108,6 +108,9 @@ public object BillingRepositoryCreator {
         ),
         logger = logger,
         ioDispatcher = ioDispatcher,
-        uiDispatcher = uiDispatcher
+        uiDispatcher = uiDispatcher,
+        // Deterministic Play Store presence check backing queryBillingAvailability.
+        // Built from the same context as the BillingClient.
+        playStoreEnvironment = DefaultPlayStoreEnvironment(context)
     )
 }

--- a/billing/src/main/kotlin/com/kanetik/billing/DefaultBillingRepository.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/DefaultBillingRepository.kt
@@ -54,10 +54,51 @@ internal class DefaultBillingRepository(
     // acknowledge) and the surrounding retry/backoff loop. uiDispatcher is
     // used only by launchFlow because PBL requires launchBillingFlow on Main.
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
-    private val uiDispatcher: CoroutineDispatcher = Dispatchers.Main
+    private val uiDispatcher: CoroutineDispatcher = Dispatchers.Main,
+    // Backs queryBillingAvailability's deterministic UNAVAILABLE verdict.
+    // Defaults to "usable" so tests that construct the repository directly and
+    // don't exercise availability keep their previous behavior.
+    private val playStoreEnvironment: PlayStoreEnvironment = PlayStoreEnvironment { true }
 ) : BillingRepository {
     override fun connectToBilling(): SharedFlow<BillingConnectionResult> {
         return billingClientStorage.connectionResultFlow
+    }
+
+    @AnyThread
+    override suspend fun queryBillingAvailability(): BillingAvailability {
+        // Step 1: deterministic, offline check. If the Play Store package is
+        // absent or disabled, billing can never work here — a stable, terminal
+        // fact the caller can safely act on.
+        if (!playStoreEnvironment.isPlayStoreUsable()) {
+            logger.d("queryBillingAvailability: Play Store package absent/disabled -> UNAVAILABLE")
+            return BillingAvailability.UNAVAILABLE
+        }
+        // Step 2: Play Store is present. Try to connect. A success is a clean
+        // AVAILABLE; ANY failure here (including a transient BILLING_UNAVAILABLE
+        // / code 3, a slow cold start, or a dropped connection) is reported as
+        // UNKNOWN, never UNAVAILABLE — the Play Store exists, so the failure is
+        // not the terminal "this device can't pay" verdict.
+        return try {
+            val result = withTimeout(AVAILABILITY_CONNECT_TIMEOUT_MS) {
+                connectToBilling().first()
+            }
+            when (result) {
+                is BillingConnectionResult.Success -> BillingAvailability.AVAILABLE
+                is BillingConnectionResult.Error -> {
+                    logger.d(
+                        "queryBillingAvailability: Play Store present but connection failed " +
+                            "(${result.exception::class.simpleName}) -> UNKNOWN"
+                    )
+                    BillingAvailability.UNKNOWN
+                }
+            }
+        } catch (te: TimeoutCancellationException) {
+            // withTimeout's own timeout — a billing-layer indeterminacy, not a
+            // scope teardown. Map to UNKNOWN. (Real scope CancellationException
+            // is a different subtype and propagates, since we don't catch it.)
+            logger.d("queryBillingAvailability: connection attempt timed out -> UNKNOWN", te)
+            BillingAvailability.UNKNOWN
+        }
     }
 
     override fun observePurchaseUpdates(): Flow<PurchaseEvent> {
@@ -578,5 +619,11 @@ internal class DefaultBillingRepository(
         // Generous enough for slow Play Billing setups, short enough to surface a
         // hung connection rather than suspending the caller forever.
         private const val CONNECTION_TIMEOUT_MS: Long = 30_000L
+
+        // queryBillingAvailability bounds its connection attempt so a hung/cold
+        // connect resolves to UNKNOWN rather than suspending the caller. Shorter
+        // than CONNECTION_TIMEOUT_MS because availability is a UI-gating probe
+        // (the caller is deciding what to show now), not a purchase-critical op.
+        private const val AVAILABILITY_CONNECT_TIMEOUT_MS: Long = 8_000L
     }
 }

--- a/billing/src/main/kotlin/com/kanetik/billing/DefaultBillingRepository.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/DefaultBillingRepository.kt
@@ -45,6 +45,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.coroutines.resume
 
 internal class DefaultBillingRepository(
@@ -78,26 +79,27 @@ internal class DefaultBillingRepository(
         // / code 3, a slow cold start, or a dropped connection) is reported as
         // UNKNOWN, never UNAVAILABLE — the Play Store exists, so the failure is
         // not the terminal "this device can't pay" verdict.
-        return try {
-            val result = withTimeout(AVAILABILITY_CONNECT_TIMEOUT_MS) {
-                connectToBilling().first()
+        // withTimeoutOrNull (not withTimeout + catch): its own deadline maps to
+        // null -> UNKNOWN, while an OUTER timeout/cancellation imposed by the
+        // caller is a different TimeoutCancellationException instance that is NOT
+        // swallowed here — it propagates, so a caller wrapping this in its own
+        // withTimeout keeps control of its deadline/cancellation contract.
+        val result = withTimeoutOrNull(AVAILABILITY_CONNECT_TIMEOUT_MS) {
+            connectToBilling().first()
+        }
+        return when (result) {
+            is BillingConnectionResult.Success -> BillingAvailability.AVAILABLE
+            is BillingConnectionResult.Error -> {
+                logger.d(
+                    "queryBillingAvailability: Play Store present but connection failed " +
+                        "(${result.exception::class.simpleName}) -> UNKNOWN"
+                )
+                BillingAvailability.UNKNOWN
             }
-            when (result) {
-                is BillingConnectionResult.Success -> BillingAvailability.AVAILABLE
-                is BillingConnectionResult.Error -> {
-                    logger.d(
-                        "queryBillingAvailability: Play Store present but connection failed " +
-                            "(${result.exception::class.simpleName}) -> UNKNOWN"
-                    )
-                    BillingAvailability.UNKNOWN
-                }
+            null -> {
+                logger.d("queryBillingAvailability: connection attempt timed out -> UNKNOWN")
+                BillingAvailability.UNKNOWN
             }
-        } catch (te: TimeoutCancellationException) {
-            // withTimeout's own timeout — a billing-layer indeterminacy, not a
-            // scope teardown. Map to UNKNOWN. (Real scope CancellationException
-            // is a different subtype and propagates, since we don't catch it.)
-            logger.d("queryBillingAvailability: connection attempt timed out -> UNKNOWN", te)
-            BillingAvailability.UNKNOWN
         }
     }
 

--- a/billing/src/main/kotlin/com/kanetik/billing/PlayStoreEnvironment.kt
+++ b/billing/src/main/kotlin/com/kanetik/billing/PlayStoreEnvironment.kt
@@ -1,0 +1,52 @@
+package com.kanetik.billing
+
+import android.content.Context
+import android.content.pm.PackageManager
+
+/**
+ * Internal: deterministic, offline check for whether the Google Play Store app
+ * is present and enabled on this device. Backs the [BillingAvailability.UNAVAILABLE]
+ * verdict of [BillingConnector.queryBillingAvailability].
+ *
+ * Abstracted behind a `fun interface` so [DefaultBillingRepository] stays
+ * context-free and unit tests can supply a fake without a real
+ * [android.content.pm.PackageManager].
+ */
+internal fun interface PlayStoreEnvironment {
+    /**
+     * `true` if the Play Store package is installed and enabled — i.e. Play
+     * Billing has a chance of working. `false` only when the package is absent
+     * or explicitly disabled, which is a stable, terminal fact about the device.
+     */
+    fun isPlayStoreUsable(): Boolean
+}
+
+/**
+ * [PlayStoreEnvironment] backed by the real [PackageManager]. Checks the
+ * Play Store package (`com.android.vending`) is installed and not disabled.
+ *
+ * Deliberately does **not** attempt to distinguish "billing supported for this
+ * account/region" — that is not knowable offline and is intentionally left to
+ * the connection attempt (which maps to [BillingAvailability.UNKNOWN] rather
+ * than a false-terminal verdict).
+ */
+internal class DefaultPlayStoreEnvironment(context: Context) : PlayStoreEnvironment {
+    // Hold the application context to avoid leaking an Activity/short-lived context.
+    private val appContext: Context = context.applicationContext
+
+    override fun isPlayStoreUsable(): Boolean {
+        return try {
+            val info = appContext.packageManager.getApplicationInfo(PLAY_STORE_PACKAGE, 0)
+            // A package can be installed but disabled (user or admin). Disabled
+            // Play Store can't service billing, so treat it as not usable.
+            info.enabled
+        } catch (e: PackageManager.NameNotFoundException) {
+            // Play Store not installed at all — common on AOSP / non-GMS devices.
+            false
+        }
+    }
+
+    private companion object {
+        const val PLAY_STORE_PACKAGE = "com.android.vending"
+    }
+}

--- a/billing/src/test/kotlin/com/kanetik/billing/DefaultBillingRepositoryAvailabilityTest.kt
+++ b/billing/src/test/kotlin/com/kanetik/billing/DefaultBillingRepositoryAvailabilityTest.kt
@@ -1,0 +1,89 @@
+package com.kanetik.billing
+
+import com.google.common.truth.Truth.assertThat
+import com.kanetik.billing.exception.BillingException
+import com.kanetik.billing.logging.BillingLogger
+import com.android.billingclient.api.BillingClient
+import com.android.billingclient.api.BillingResult
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+/**
+ * Verifies [DefaultBillingRepository.queryBillingAvailability]'s
+ * terminal-vs-transient contract:
+ *  - Play Store package absent/disabled is the only path to the terminal
+ *    [BillingAvailability.UNAVAILABLE] verdict (no connection attempted).
+ *  - With the Play Store present, a successful connection is [AVAILABLE]; ANY
+ *    connection failure (including a transient `BILLING_UNAVAILABLE`) or a
+ *    timeout is [UNKNOWN], never UNAVAILABLE — so a consumer can't be tricked
+ *    into a terminal decision by a transient first-launch hiccup.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class DefaultBillingRepositoryAvailabilityTest {
+
+    private fun repo(
+        connection: MutableSharedFlow<BillingConnectionResult>,
+        playStoreUsable: Boolean,
+        scheduler: kotlinx.coroutines.test.TestCoroutineScheduler
+    ): DefaultBillingRepository {
+        val storage = mockk<BillingClientStorage>(relaxed = true) {
+            every { connectionResultFlow } returns connection.asSharedFlow()
+        }
+        return DefaultBillingRepository(
+            billingClientStorage = storage,
+            logger = BillingLogger.Noop,
+            ioDispatcher = UnconfinedTestDispatcher(scheduler),
+            uiDispatcher = UnconfinedTestDispatcher(scheduler),
+            playStoreEnvironment = PlayStoreEnvironment { playStoreUsable }
+        )
+    }
+
+    @Test
+    fun `Play Store absent or disabled returns UNAVAILABLE without connecting`() = runTest {
+        // A connection flow that would never emit — if the code tried to connect,
+        // it'd hang until timeout. It must short-circuit before that.
+        val connection = MutableSharedFlow<BillingConnectionResult>()
+        val r = repo(connection, playStoreUsable = false, scheduler = testScheduler)
+
+        assertThat(r.queryBillingAvailability()).isEqualTo(BillingAvailability.UNAVAILABLE)
+    }
+
+    @Test
+    fun `Play Store present and connection success returns AVAILABLE`() = runTest {
+        val connection = MutableSharedFlow<BillingConnectionResult>(replay = 1).apply {
+            tryEmit(BillingConnectionResult.Success)
+        }
+        val r = repo(connection, playStoreUsable = true, scheduler = testScheduler)
+
+        assertThat(r.queryBillingAvailability()).isEqualTo(BillingAvailability.AVAILABLE)
+    }
+
+    @Test
+    fun `Play Store present but transient BILLING_UNAVAILABLE returns UNKNOWN not UNAVAILABLE`() = runTest {
+        val code3 = BillingResult.newBuilder()
+            .setResponseCode(BillingClient.BillingResponseCode.BILLING_UNAVAILABLE)
+            .setDebugMessage("Billing service unavailable on device.")
+            .build()
+        val connection = MutableSharedFlow<BillingConnectionResult>(replay = 1).apply {
+            tryEmit(BillingConnectionResult.Error(BillingException.fromResult(code3)))
+        }
+        val r = repo(connection, playStoreUsable = true, scheduler = testScheduler)
+
+        assertThat(r.queryBillingAvailability()).isEqualTo(BillingAvailability.UNKNOWN)
+    }
+
+    @Test
+    fun `Play Store present but connection hangs returns UNKNOWN via timeout`() = runTest {
+        // Never emits; withTimeout fires in virtual time -> UNKNOWN.
+        val connection = MutableSharedFlow<BillingConnectionResult>()
+        val r = repo(connection, playStoreUsable = true, scheduler = testScheduler)
+
+        assertThat(r.queryBillingAvailability()).isEqualTo(BillingAvailability.UNKNOWN)
+    }
+}


### PR DESCRIPTION
## Summary

Adds `BillingConnector.queryBillingAvailability(): BillingAvailability` — a deterministic verdict that disambiguates a **terminal** "this device can't do Play Billing" state from a merely **transient** failure.

The raw `BILLING_UNAVAILABLE` (code 3) response is returned both when the Play Store is genuinely absent **and** when billing is momentarily unavailable (Play Store mid-update, account still syncing post-install). Gating irreversible decisions (free-tier grant, hiding a purchase CTA) on it is a known footgun. This check resolves Play Store package presence/enabled state offline first:

- Play Store absent/disabled → `UNAVAILABLE` (terminal, safe to act on)
- Play Store present + connection succeeds → `AVAILABLE`
- Play Store present + connection fails (incl. transient code 3) or times out → `UNKNOWN` (callers must not treat as terminal)

## Changes

- `BillingAvailability` enum — `AVAILABLE` / `UNAVAILABLE` / `UNKNOWN`
- `PlayStoreEnvironment` `fun interface` + `DefaultPlayStoreEnvironment` — offline `com.android.vending` presence/enabled check
- `DefaultBillingRepository.queryBillingAvailability()` — two-step resolution, bounded by an 8s `AVAILABILITY_CONNECT_TIMEOUT_MS`
- `queryBillingAvailability` added as a **defaulted** interface method (returns `UNKNOWN`) so existing hand-rolled fakes keep compiling
- Wired via `BillingRepositoryCreator`; `0.1.4-SNAPSHOT` → `0.1.5-SNAPSHOT`; CHANGELOG

## Tests

`DefaultBillingRepositoryAvailabilityTest` covers all four paths: absent/disabled short-circuit (no connect), success, transient code-3 → UNKNOWN, hung connection → UNKNOWN via virtual-time timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
